### PR TITLE
fix goroutine leak in event forwarder / fanout

### DIFF
--- a/sinks/eventsink.go
+++ b/sinks/eventsink.go
@@ -186,14 +186,16 @@ func (r *EventForwarder) loop(ctx context.Context) error {
 }
 
 func (r *EventForwarder) runNext(ctx context.Context, pos int64) (int64, error) {
-	aCtx := repo.SetAuthInfo(ctx, &repo.AuthInfo{
+	aCtx, cancel := context.WithCancel(repo.SetAuthInfo(ctx, &repo.AuthInfo{
 		Claims: repo.JWTClaims{
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject: "internal://event-forwarder",
 			},
 			Scope: "superuser doc_read",
 		},
-	})
+	}))
+
+	defer cancel()
 
 	log, err := r.documents.Eventlog(aCtx, &repository.GetEventlogRequest{
 		After:       pos,


### PR DESCRIPTION
TLDR: The fanout logic assumed that the subscriber context would be cancelled fairly quick, as it was meant to be used in RPC request processing. But the event forwarder used a long-lived context that wouldn't cancel until it hits an error that requires a restart.

![goroutine_leak](https://user-images.githubusercontent.com/30441/231419550-975cbab0-4c82-4d6c-ab43-b2aff23f7574.png)

As the instance with the leak was identified by the graph I connected to the internal debug server using kubectl:

```
kubectl port-forward -n stage02 pods/elephant-repository-cd5b749d5-k8qzv 3081:1081
```

I then visited the http://localhost:3081/debug/pprof/ endpoint and navigated to the goroutine information page (/debug/pprof/goroutine?debug=1):

```
goroutine profile: total 171
144 @ 0x43bf56 0x406f9d 0x406a98 0x113999c 0x46f121
#	0x113999b	github.com/ttab/elephant/repository.(*FanOut[...]).Listen+0x9b	/usr/src/repository/fanout.go:24

3 @ 0x43bf56 0x434637 0x469769 0x52ab72 0x52bf59 0x52bf47 0x5d1ac9 0x5e3965 0x6ea171 0x67023f 0x67039d 0x6f011c 0x46f121
#	0x469768	internal/poll.runtime_pollWait+0x88		/usr/local/go/src/runtime/netpoll.go:306
#	0x52ab71	internal/poll.(*pollDesc).wait+0x31		/usr/local/go/src/internal/poll/fd_poll_runtime.go:84
#	0x52bf58	internal/poll.(*pollDesc).waitRead+0x298	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
#	0x52bf46	internal/poll.(*FD).Read+0x286			/usr/local/go/src/internal/poll/fd_unix.go:167
#	0x5d1ac8	net.(*netFD).Read+0x28				/usr/local/go/src/net/fd_posix.go:55
#	0x5e3964	net.(*conn).Read+0x44				/usr/local/go/src/net/net.go:183
#	0x6ea170	net/http.(*connReader).Read+0x170		/usr/local/go/src/net/http/server.go:782
#	0x67023e	bufio.(*Reader).fill+0xfe			/usr/local/go/src/bufio/bufio.go:106
#	0x67039c	bufio.(*Reader).Peek+0x5c			/usr/local/go/src/bufio/bufio.go:144
#	0x6f011b	net/http.(*conn).serve+0x77b			/usr/local/go/src/net/http/server.go:2030

2 @ 0x43bf56 0x406f9d 0x406a98 0xe090b2 0x46f121
#	0xe090b1	github.com/ttab/elephant/internal.ListenAndServeContext.func1+0x31	/usr/src/internal/http.go:104

[...]
```

This pointed to 144 goroutines being blocked on https://github.com/ttab/elephant/blob/ffc8c34aa3f21e94236114778653ed990f732d63/repository/fanout.go#L24 waiting for the context to be cancelled.

As the behaviour started with the new eventlog forwarder I quickly realised that the eventlog polling there broke some basic assumptions based on request contexts by using the Documents service directly.

The forwarder now uses a context that gets cancelled after each eventlog poll run.

