### PR TITLE
add value collection support to revisor

### DIFF
--- a/revisor/document_constraint.go
+++ b/revisor/document_constraint.go
@@ -58,6 +58,14 @@ func (dc DocumentConstraint) Matches(
 		if err != nil {
 			return NoMatch
 		}
+
+		vCtx.coll.CollectValue(ValueAnnotation{
+			Ref: []EntityRef{{
+				RefType: RefTypeAttribute,
+				Name:    k,
+			}},
+			Value: value,
+		})
 	}
 
 	return Matches
@@ -88,6 +96,14 @@ func (dc DocumentConstraint) checkAttributes(
 
 			continue
 		}
+
+		vCtx.coll.CollectValue(ValueAnnotation{
+			Ref: []EntityRef{{
+				RefType: RefTypeAttribute,
+				Name:    k,
+			}},
+			Value: value,
+		})
 	}
 
 	return res

--- a/revisor/string_constraint.go
+++ b/revisor/string_constraint.go
@@ -117,6 +117,8 @@ func (sc *StringConstraint) Requirement() string {
 }
 
 type ValidationContext struct {
+	coll ValueCollector
+
 	TemplateData TemplateValues
 	ValidateHTML func(policyName, value string) error
 }


### PR DESCRIPTION
This has been extracted from the indexing draft PR to support inferred typing of block data when indexing in a FT index.