### PR TITLE
scope check consistency update for Documents service

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,99 @@
+# Permissions
+
+Permissions are controlled by a set of scopes and document ACL lists.
+
+* ACL read access checks can be circumvented by: doc_read_all, doc_admin
+* ACL write access checks can be circumvented by: doc_admin
+
+## Scopes
+
+``` go
+	ScopeDocumentAdmin   = "doc_admin"
+	ScopeDocumentReadAll = "doc_read_all"
+	ScopeDocumentRead    = "doc_read"
+	ScopeDocumentDelete  = "doc_delete"
+	ScopeDocumentWrite   = "doc_write"
+	ScopeDocumentImport  = "doc_import"
+	ScopeEventlogRead    = "eventlog_read"
+	ScopeMetricsAdmin    = "metrics_admin"
+	ScopeMetricsWrite    = "metrics_write"
+	ScopeReportAdmin     = "report_admin"
+	ScopeReportRun       = "report_run"
+	ScopeSchemaAdmin     = "schema_admin"
+	ScopeSchemaRead      = "schema_read"
+	ScopeWorkflowAdmin   = "workflow_admin"
+```
+
+Some scopes can have subscopes, like in the case of "metrics_write" where access can be given to write a specific metric kind through the scope "metrics_write:word_count".
+
+## Documents
+
+### GetStatusHistory
+
+Requires one of: doc_read, doc_read_all, doc_admin
+
+ACL read access check.
+
+### GetPermissions
+
+Requires one of: doc_read, doc_write, doc_delete, doc_read_all, doc_admin
+
+All clients with document scopes can read permissions.
+
+### Eventlog
+
+Requires one of: eventlog_read, doc_admin
+
+### Delete
+
+Requires one of: doc_delete, doc_admin
+
+ACL write access check.
+
+### Get
+
+Requires one of: doc_read, doc_read_all, doc_admin
+
+ACL read access check.
+
+### GetHistory
+
+Requires one of: doc_read, doc_read_all, doc_admin
+
+ACL read access check.
+
+### GetMeta
+
+Requires one of: doc_read, doc_read_all, doc_admin
+
+ACL read access check.
+
+### Update
+
+Requires one of: doc_write, doc_admin
+
+ACL write access check.
+
+Use of import directives requires one of: doc_import, doc_admin
+
+### Validate
+
+No specific permissions required.
+
+### Lock
+
+Requires one of: doc_write, doc_delete, doc_admin
+
+ACL write access check.
+
+### ExtendLock
+
+Requires one of: doc_write, doc_delete, doc_admin
+
+ACL write access check.
+
+### Unlock
+
+Requires one of: doc_write, doc_delete, doc_admin
+
+ACL write access check.

--- a/repository/permissions.go
+++ b/repository/permissions.go
@@ -28,14 +28,12 @@ func (p Permission) Name() string {
 }
 
 const (
-	// TODO: ScopeSuperuser is a bad scope, introducing doc_admin and
-	// doc_read_all to replace usage of superuser.
-	ScopeSuperuser       = "superuser"
 	ScopeDocumentAdmin   = "doc_admin"
 	ScopeDocumentReadAll = "doc_read_all"
 	ScopeDocumentRead    = "doc_read"
 	ScopeDocumentDelete  = "doc_delete"
 	ScopeDocumentWrite   = "doc_write"
+	ScopeDocumentImport  = "doc_import"
 	ScopeEventlogRead    = "eventlog_read"
 	ScopeMetricsAdmin    = "metrics_admin"
 	ScopeMetricsWrite    = "metrics_write"

--- a/repository/schema_api.go
+++ b/repository/schema_api.go
@@ -29,8 +29,7 @@ var _ repository.Schemas = &SchemasService{}
 func (a *SchemasService) GetAllActive(
 	ctx context.Context, req *repository.GetAllActiveSchemasRequest,
 ) (*repository.GetAllActiveSchemasResponse, error) {
-	_, err := RequireAnyScope(ctx,
-		ScopeSuperuser, ScopeSchemaAdmin, ScopeSchemaRead)
+	_, err := RequireAnyScope(ctx, ScopeSchemaAdmin, ScopeSchemaRead)
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +111,7 @@ func (a *SchemasService) waitIfSchemasAreUnchanged(
 func (a *SchemasService) Get(
 	ctx context.Context, req *repository.GetSchemaRequest,
 ) (*repository.GetSchemaResponse, error) {
-	_, err := RequireAnyScope(ctx,
-		ScopeSuperuser, ScopeSchemaAdmin, ScopeSchemaRead)
+	_, err := RequireAnyScope(ctx, ScopeSchemaAdmin, ScopeSchemaRead)
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +143,7 @@ func (a *SchemasService) Get(
 func (a *SchemasService) Register(
 	ctx context.Context, req *repository.RegisterSchemaRequest,
 ) (*repository.RegisterSchemaResponse, error) {
-	_, err := RequireAnyScope(ctx,
-		ScopeSuperuser, ScopeSchemaAdmin)
+	_, err := RequireAnyScope(ctx, ScopeSchemaAdmin)
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +194,7 @@ func (a *SchemasService) Register(
 func (a *SchemasService) SetActive(
 	ctx context.Context, req *repository.SetActiveSchemaRequest,
 ) (*repository.SetActiveSchemaResponse, error) {
-	_, err := RequireAnyScope(ctx,
-		ScopeSuperuser, ScopeSchemaAdmin)
+	_, err := RequireAnyScope(ctx, ScopeSchemaAdmin)
 	if err != nil {
 		return nil, err
 	}

--- a/sinks/eventsink.go
+++ b/sinks/eventsink.go
@@ -203,7 +203,7 @@ func (r *EventForwarder) runNext(ctx context.Context, pos int64) (int64, error) 
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject: "internal://event-forwarder",
 			},
-			Scope: "superuser doc_read",
+			Scope: "doc_read_all eventlog_read",
 		},
 	}))
 


### PR DESCRIPTION
Introducing doc_import to replace import_directive. Making sure that doc_admin is consistently used. Require any doc-write scope for lock operations.

Looking at the permissions.md document it really feels like the basic, non-conditional, scope checks should be something we do declaratively.