### PR TITLE
add support for a negative starting point in documents.Eventlog()

### DIFF
--- a/postgres/query.sql
+++ b/postgres/query.sql
@@ -339,6 +339,12 @@ WHERE id > @after
 ORDER BY id ASC
 LIMIT sqlc.arg(row_limit);
 
+-- name: GetLastEvent :one
+SELECT id, event, uuid, timestamp, updater, type, version, status, status_id, acl
+FROM eventlog
+ORDER BY id DESC
+LIMIT 1;
+
 -- name: ConfigureEventsink :exec
 INSERT INTO eventsink(name, configuration) VALUES(@name, @config)
 ON CONFLICT (name) DO UPDATE SET

--- a/postgres/query.sql.go
+++ b/postgres/query.sql.go
@@ -900,6 +900,44 @@ func (q *Queries) GetJobLock(ctx context.Context, name string) (GetJobLockRow, e
 	return i, err
 }
 
+const getLastEvent = `-- name: GetLastEvent :one
+SELECT id, event, uuid, timestamp, updater, type, version, status, status_id, acl
+FROM eventlog
+ORDER BY id DESC
+LIMIT 1
+`
+
+type GetLastEventRow struct {
+	ID        int64
+	Event     string
+	UUID      uuid.UUID
+	Timestamp pgtype.Timestamptz
+	Updater   pgtype.Text
+	Type      pgtype.Text
+	Version   pgtype.Int8
+	Status    pgtype.Text
+	StatusID  pgtype.Int8
+	Acl       []byte
+}
+
+func (q *Queries) GetLastEvent(ctx context.Context) (GetLastEventRow, error) {
+	row := q.db.QueryRow(ctx, getLastEvent)
+	var i GetLastEventRow
+	err := row.Scan(
+		&i.ID,
+		&i.Event,
+		&i.UUID,
+		&i.Timestamp,
+		&i.Updater,
+		&i.Type,
+		&i.Version,
+		&i.Status,
+		&i.StatusID,
+		&i.Acl,
+	)
+	return i, err
+}
+
 const getMetricKind = `-- name: GetMetricKind :one
 SELECT name, aggregation
 FROM metric_kind 

--- a/repository/docstore.go
+++ b/repository/docstore.go
@@ -36,6 +36,9 @@ type DocStore interface {
 	GetEventlog(
 		ctx context.Context, after int64, limit int32,
 	) ([]Event, error)
+	GetLastEvent(
+		ctx context.Context,
+	) (*Event, error)
 	OnEventlog(
 		ctx context.Context, ch chan int64,
 	)

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -381,6 +381,29 @@ func (s *PGDocStore) GetDocument(
 	return &d, nil
 }
 
+func (s *PGDocStore) GetLastEvent(
+	ctx context.Context,
+) (*Event, error) {
+	res, err := s.reader.GetLastEvent(ctx)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, DocStoreErrorf(ErrCodeNotFound, "not found")
+	} else if err != nil {
+		return nil, fmt.Errorf("database query failed: %w", err)
+	}
+
+	return &Event{
+		ID:        res.ID,
+		Event:     EventType(res.Event),
+		UUID:      res.UUID,
+		Timestamp: res.Timestamp.Time,
+		Updater:   res.Updater.String,
+		Type:      res.Type.String,
+		Version:   res.Version.Int64,
+		Status:    res.Status.String,
+		StatusID:  res.StatusID.Int64,
+	}, nil
+}
+
 func (s *PGDocStore) GetEventlog(
 	ctx context.Context, after int64, limit int32,
 ) ([]Event, error) {


### PR DESCRIPTION
A negative starting point -N is used to get the last N events in the log.