### PR TITLE
fix logic error in handling negative after when the log is empty

### DIFF
--- a/repository/documents_api.go
+++ b/repository/documents_api.go
@@ -294,14 +294,16 @@ func (a *DocumentsService) Eventlog(
 	after := req.After
 	if after < 0 {
 		evt, err := a.store.GetLastEvent(ctx)
-		if IsDocStoreErrorCode(err, ErrCodeNotFound) {
+
+		switch {
+		case IsDocStoreErrorCode(err, ErrCodeNotFound):
 			after = 0
-		} else if err != nil {
+		case err != nil:
 			return nil, twirp.InternalErrorf(
 				"failed to get last event: %w", err)
+		default:
+			after = evt.ID + after
 		}
-
-		after = evt.ID + after
 	}
 
 	limit := req.BatchSize

--- a/repository/documents_api_test.go
+++ b/repository/documents_api_test.go
@@ -52,6 +52,16 @@ func TestIntegrationBasicCrud(t *testing.T) {
 
 	ctx := test.Context(t)
 
+	t.Run("NegativeEventlogAfterOnEmpty", func(t *testing.T) {
+		log, err := client.Eventlog(ctx, &repository.GetEventlogRequest{
+			After: -1,
+		})
+
+		test.Must(t, err, "get eventlog")
+		test.Equal(t, 0, len(log.Items),
+			"no eventlog items should be returned")
+	})
+
 	const (
 		docUUID = "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5"
 		docURI  = "article://test/123"


### PR DESCRIPTION
The not found error was mishandled as we continued on to access evt even when it was known to be nil. Using switch with default case for success instead.

Added test to verify bug and prevent regression.