### PR TITLE
introduce a "s" SetStatusPermission for ACLs

### DIFF
--- a/repository/permissions.go
+++ b/repository/permissions.go
@@ -16,12 +16,14 @@ const (
 	ReadPermission      Permission = "r"
 	WritePermission     Permission = "w"
 	MetaWritePermission Permission = "m"
+	SetStatusPermission Permission = "s"
 )
 
 var vailidPermissions = []Permission{
 	ReadPermission,
 	WritePermission,
 	MetaWritePermission,
+	SetStatusPermission,
 }
 
 func IsValidPermission(p Permission) bool {
@@ -36,6 +38,8 @@ func (p Permission) Name() string {
 		return "write"
 	case MetaWritePermission:
 		return "meta write"
+	case SetStatusPermission:
+		return "set status"
 	}
 
 	return strconv.Quote(string(p))

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -1263,7 +1263,10 @@ func (s *PGDocStore) buildStatusRuleInput(
 	} else if d == nil {
 		d, meta, err := s.loadDocument(
 			ctx, q, uuid, status.Version)
-		if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return StatusRuleInput{}, DocStoreErrorf(
+				ErrCodeNotFound, "cannot set a status for a version that doesn't exist")
+		} else if err != nil {
 			return StatusRuleInput{}, fmt.Errorf(
 				"failed to retrieve document for rule evaluation: %w", err)
 		}


### PR DESCRIPTION
Makes it possible to grant subjects the permission to set statuses independently of write permissions.