### PR TITLE
sse: use RequireAnyScope() to provide auth/access error messages

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
           go-version: '1.22.4'
           cache: false # Let golangcilint handle caching
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59
           args: --timeout=4m


### PR DESCRIPTION
The SSE endpoint will now provide details with auth errors, like this:

```
HTTP/1.1 403 Forbidden
Date: Mon, 17 Jun 2024 10:44:56 GMT
Content-Length: 89
Content-Type: text/plain; charset=utf-8

twirp error permission_denied: one of the the scopes eventlog_read, doc_admin is required
```