### PR TITLE
handle non-document updates on documents that don't exist

### DIFF
--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -1533,6 +1533,11 @@ func (s *PGDocStore) Update(
 			return nil, err
 		}
 
+		if !info.Exists && state.Doc == nil {
+			return nil, DocStoreErrorf(ErrCodeNotFound,
+				"non-document update for document that doesn't exist")
+		}
+
 		state.Version = info.Info.CurrentVersion
 		state.Exists = info.Exists
 		state.Language = info.Language


### PR DESCRIPTION
Updates without a document, f.ex. only setting an ACL or status, on documents that don't exist results in a internal error (caught by database constraints). This adds a check that rejects the update with a 404 instead. 