### PR TITLE
handle create conflicts gracefully

### DIFF
--- a/repository/documents_api.go
+++ b/repository/documents_api.go
@@ -1594,6 +1594,8 @@ func twirpErrorFromDocumentUpdateError(err error) error {
 		return twirp.FailedPrecondition.Error(err.Error())
 	case IsDocStoreErrorCode(err, ErrCodeBadRequest):
 		return twirp.InvalidArgumentError("document", err.Error())
+	case IsDocStoreErrorCode(err, ErrCodeFailedPrecondition):
+		return twirp.FailedPrecondition.Error(err.Error())
 	case IsDocStoreErrorCode(err, ErrCodePermissionDenied):
 		return twirp.PermissionDenied.Error(err.Error())
 	case IsDocStoreErrorCode(err, ErrCodeDeleteLock):


### PR DESCRIPTION
Fix and regression test for the error `failed to update document: failed to create version in database: ERROR: duplicate key value violates unique constraint "document_version_pkey" (SQLSTATE 23505):`. This error occurred when two clients attempted to create a document with the same UUID at the same time.

Document writes are serialised by locking the document row, and when a document is created there is no existing row to lock, so the collision is deferred to the document version insert.

The fix detects when document version creation fails with a constraint error on the primary key, and reports that as a create conflict (if the document is being created) instead of a internal database error.