### PR TITLE
use NewAPIServer for /version and /debug/bom endpoints

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,5 +41,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,11 @@ RUN go mod download && go mod verify
 ADD . ./
 
 ARG TARGETOS TARGETARCH
+ARG VERSION=v0.0.0-dev
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -o /build/repository ./cmd/repository
+    go build \
+      -ldflags "-X main.version=$VERSION" \
+      -o /build/repository ./cmd/repository
 
 FROM alpine:3.23
 

--- a/cmd/repository/main.go
+++ b/cmd/repository/main.go
@@ -658,7 +658,11 @@ func runServer(ctx context.Context, c *cli.Command) error {
 	var serverOpts []elephantine.APIServerOption
 
 	serverOpts = append(serverOpts,
-		elephantine.APIServerVersion(version))
+		elephantine.APIServerVersion(version),
+		elephantine.APIServerModules(
+			"github.com/ttab/newsdoc",
+			"github.com/ttab/revisor",
+		))
 
 	if certFile != "" {
 		serverOpts = append(serverOpts,

--- a/cmd/repository/main.go
+++ b/cmd/repository/main.go
@@ -37,6 +37,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var version string // set via -ldflags at build time
+
 func main() {
 	err := godotenv.Load()
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -653,9 +655,27 @@ func runServer(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("failed to set up router: %w", err)
 	}
 
-	healthServer := elephantine.NewHealthServer(logger, profileAddr)
+	var serverOpts []elephantine.APIServerOption
 
-	healthServer.AddReadyFunction("s3", func(ctx context.Context) error {
+	serverOpts = append(serverOpts,
+		elephantine.APIServerVersion(version))
+
+	if certFile != "" {
+		serverOpts = append(serverOpts,
+			elephantine.APIServerTLS(tlsAddr, certFile, keyFile))
+	}
+
+	srv := elephantine.NewAPIServer(logger, addr, profileAddr, serverOpts...)
+
+	if len(corsHosts) > 0 {
+		srv.CORS.Hosts = corsHosts
+	}
+
+	srv.CORS.AllowedHeaders = append(srv.CORS.AllowedHeaders, "Last-Event-ID")
+
+	srv.Mux.Handle("/", router)
+
+	srv.Health.AddReadyFunction("s3", func(ctx context.Context) error {
 		testUUID := uuid.New()
 
 		key := fmt.Sprintf(
@@ -693,52 +713,12 @@ func runServer(ctx context.Context, c *cli.Command) error {
 		return nil
 	})
 
-	healthServer.AddReadyFunction("postgres", func(ctx context.Context) error {
+	srv.Health.AddReadyFunction("postgres", func(ctx context.Context) error {
 		q := postgres.New(dbpool)
 
 		_, err := q.GetActiveSchemas(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to read schemas: %w", err)
-		}
-
-		return nil
-	})
-
-	router.GET("/health/alive", func(
-		w http.ResponseWriter, _ *http.Request, _ httprouter.Params,
-	) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-
-		_, _ = fmt.Fprintln(w, "I AM ALIVE!")
-	})
-
-	healthServer.AddReadyFunction("api_liveness", func(ctx context.Context) error {
-		req, err := http.NewRequestWithContext(
-			ctx, http.MethodGet, fmt.Sprintf(
-				"http://localhost%s/health/alive",
-				addr,
-			), nil,
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to create liveness check request: %w", err)
-		}
-
-		var client http.Client
-
-		res, err := client.Do(req)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to perform liveness check request: %w", err)
-		}
-
-		_ = res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf(
-				"api liveness endpoint returned non-ok status: %s",
-				res.Status)
 		}
 
 		return nil
@@ -777,9 +757,7 @@ func runServer(ctx context.Context, c *cli.Command) error {
 	serverGroup.Go(func() error {
 		logger.Debug("starting API server")
 
-		err := repository.ListenAndServe(
-			gCtx, addr, tlsAddr,
-			router, corsHosts, certFile, keyFile)
+		err := srv.ListenAndServe(gCtx)
 		if err != nil {
 			return fmt.Errorf("API server error: %w", err)
 		}
@@ -800,17 +778,6 @@ func runServer(ctx context.Context, c *cli.Command) error {
 		}()
 
 		sseSubsystem.Run(gCtx)
-
-		return nil
-	})
-
-	serverGroup.Go(func() error {
-		logger.Debug("starting health server")
-
-		err := healthServer.ListenAndServe(gCtx)
-		if err != nil {
-			return fmt.Errorf("health server error: %w", err)
-		}
 
 		return nil
 	})

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ttab/darknut v0.1.3
 	github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494
 	github.com/ttab/elephant-api v0.22.1
-	github.com/ttab/elephantine v0.25.0
+	github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835
 	github.com/ttab/langos v0.1.1
 	github.com/ttab/mage v0.9.1
 	github.com/ttab/newsdoc v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ttab/darknut v0.1.3
 	github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494
 	github.com/ttab/elephant-api v0.22.1
-	github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835
+	github.com/ttab/elephantine v0.26.0
 	github.com/ttab/langos v0.1.1
 	github.com/ttab/mage v0.9.1
 	github.com/ttab/newsdoc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494 h1:+H9OmC2RhDEI8f6t
 github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494/go.mod h1:455AWlpLkAwuFrBZ8EXAtnJ/kZL6hhvC0CT9l7gNbIc=
 github.com/ttab/elephant-api v0.22.1 h1:XJCFLVpt99rQpLkNJhPLQL2fFpUZPQu8i8VfIE9K8do=
 github.com/ttab/elephant-api v0.22.1/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
-github.com/ttab/elephantine v0.25.0 h1:0Z9tvlqzVD2rUSwwihOK/iqtjoPO0Xh0JzTCWUSRzMM=
-github.com/ttab/elephantine v0.25.0/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
+github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835 h1:9hXHPHEe4QpLIgMMW2jbIVxWXdNFEaUPoI97zkguhPg=
+github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
 github.com/ttab/langos v0.1.1 h1:87AksvnO5AWdXEKnb5Ga5H+dXvigDX8I1y46pTc8vDE=
 github.com/ttab/langos v0.1.1/go.mod h1:+E1sOSvBJIbE5VM0m2rfr83aqw0kZbfe/clqNtwSP8w=
 github.com/ttab/mage v0.9.1 h1:0X1AR5G/nevuLYtJW5BgN03glBicJZxb5z7jIUHN5ro=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494 h1:+H9OmC2RhDEI8f6t
 github.com/ttab/eleconf v0.2.1-0.20260407125032-07bbda48a494/go.mod h1:455AWlpLkAwuFrBZ8EXAtnJ/kZL6hhvC0CT9l7gNbIc=
 github.com/ttab/elephant-api v0.22.1 h1:XJCFLVpt99rQpLkNJhPLQL2fFpUZPQu8i8VfIE9K8do=
 github.com/ttab/elephant-api v0.22.1/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
-github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835 h1:9hXHPHEe4QpLIgMMW2jbIVxWXdNFEaUPoI97zkguhPg=
-github.com/ttab/elephantine v0.25.1-0.20260417064516-521209c85835/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
+github.com/ttab/elephantine v0.26.0 h1:jxmgZIZ1XKoKFrB5OtdD/umPcJL3xYMoO+dFLmPwNmQ=
+github.com/ttab/elephantine v0.26.0/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
 github.com/ttab/langos v0.1.1 h1:87AksvnO5AWdXEKnb5Ga5H+dXvigDX8I1y46pTc8vDE=
 github.com/ttab/langos v0.1.1/go.mod h1:+E1sOSvBJIbE5VM0m2rfr83aqw0kZbfe/clqNtwSP8w=
 github.com/ttab/mage v0.9.1 h1:0X1AR5G/nevuLYtJW5BgN03glBicJZxb5z7jIUHN5ro=


### PR DESCRIPTION
Switch from manual HealthServer + ListenAndServe to elephantine's NewAPIServer, which provides the /version endpoint (JSON build info) and /debug/bom on the health server. The git tag is stamped into the binary via -ldflags in the Dockerfile and forwarded from the GitHub Actions workflow.