### PR TITLE
Implicit workflow

### DIFF
--- a/cmd/repository/main.go
+++ b/cmd/repository/main.go
@@ -186,6 +186,14 @@ Intended for bootstrapping disposable environments. Having this always on in
 production is a BAD IDEA! Migrations can be expensive and need to be planned.`,
 				Sources: cli.EnvVars("MIGRATE_DB"),
 			},
+			&cli.BoolFlag{
+				Name: "emit-workflow-event",
+				Usage: `Emit the legacy standalone "workflow" event alongside the
+workflow_state fields that are folded onto the triggering document or status
+event. Transition aid for external consumers; will be removed in a future
+release.`,
+				Sources: cli.EnvVars("EMIT_WORKFLOW_EVENT"),
+			},
 		}, elephantine.AuthenticationCLIFlags()...),
 	}
 
@@ -206,19 +214,20 @@ production is a BAD IDEA! Migrations can be expensive and need to be planned.`,
 
 func runServer(ctx context.Context, c *cli.Command) error {
 	var (
-		addr            = c.String("addr")
-		tlsAddr         = c.String("tls-addr")
-		certFile        = c.String("cert-file")
-		keyFile         = c.String("key-file")
-		profileAddr     = c.String("profile-addr")
-		logLevel        = c.String("log-level")
-		defaultLanguage = c.String("default-language")
-		defaultTimezone = c.String("default-timezone")
-		noCharCounter   = c.Bool("no-charcounter")
-		noWebsocket     = c.Bool("no-websocket")
-		noSSE           = c.Bool("no-sse")
-		corsHosts       = c.StringSlice("cors-host")
-		migrateDB       = c.Bool("migrate-db")
+		addr              = c.String("addr")
+		tlsAddr           = c.String("tls-addr")
+		certFile          = c.String("cert-file")
+		keyFile           = c.String("key-file")
+		profileAddr       = c.String("profile-addr")
+		logLevel          = c.String("log-level")
+		defaultLanguage   = c.String("default-language")
+		defaultTimezone   = c.String("default-timezone")
+		noCharCounter     = c.Bool("no-charcounter")
+		noWebsocket       = c.Bool("no-websocket")
+		noSSE             = c.Bool("no-sse")
+		corsHosts         = c.StringSlice("cors-host")
+		migrateDB         = c.Bool("migrate-db")
+		emitWorkflowEvent = c.Bool("emit-workflow-event")
 	)
 
 	logger := elephantine.SetUpLogger(logLevel, os.Stdout)
@@ -350,6 +359,7 @@ func runServer(ctx context.Context, c *cli.Command) error {
 			MetricsCalculators: inMet,
 			TypeConfigurations: typeConfs,
 			DefaultTZ:          defaultTZ,
+			EmitWorkflowEvent:  emitWorkflowEvent,
 		})
 	if err != nil {
 		return fmt.Errorf("failed to create doc store: %w", err)

--- a/repository/common_test.go
+++ b/repository/common_test.go
@@ -177,6 +177,7 @@ type testingServerOptions struct {
 	ConfigDirectory    string
 	Schemas            []eleconf.LoadedSchema
 	NoCoreSchemas      bool
+	EmitWorkflowEvent  bool
 }
 
 func testingAPIServer(
@@ -223,6 +224,7 @@ func testingAPIServer(
 			DeleteTimeout:      1 * time.Second,
 			MetricsCalculators: inMet,
 			TypeConfigurations: typeConf,
+			EmitWorkflowEvent:  opts.EmitWorkflowEvent,
 		})
 	test.Must(t, err, "create doc store")
 

--- a/repository/common_test.go
+++ b/repository/common_test.go
@@ -41,7 +41,7 @@ type TestContext struct {
 	SigningKey       *ecdsa.PrivateKey
 	Server           *httptest.Server
 	Validator        *repository.Validator
-	WorkflowProvider repository.WorkflowProvider
+	WorkflowProvider *repository.Workflows
 	Documents        rpc.Documents
 	Schemas          rpc.Schemas
 	Workflows        rpc.Workflows

--- a/repository/docstore.go
+++ b/repository/docstore.go
@@ -348,9 +348,10 @@ func (wf DocumentWorkflow) Step(state WorkflowState, step WorkflowStep) Workflow
 	checkpoint := wf.Configuration.Checkpoint
 	negCheckpoint := wf.Configuration.NegativeCheckpoint
 
-	isCheckpoint := step.Status != nil && step.Status.Name == checkpoint
+	isCheckpoint := checkpoint != "" && step.Status != nil && step.Status.Name == checkpoint
 	isStep := step.Status != nil && slices.Contains(wf.Configuration.Steps, step.Status.Name)
-	atCheckpoint := state.Step == checkpoint || state.Step == negCheckpoint
+	atCheckpoint := (checkpoint != "" && state.Step == checkpoint) ||
+		(negCheckpoint != "" && state.Step == negCheckpoint)
 
 	// Creating a new version when at a checkpoint resets the step to zero.
 	if step.Version > 0 && atCheckpoint {

--- a/repository/documents_api_test.go
+++ b/repository/documents_api_test.go
@@ -1240,8 +1240,9 @@ func TestIntegrationBulkCrud(t *testing.T) {
 				Creator: testUserURI,
 			},
 		},
-		CreatorUri: "user://test/testintegrationbulkcrud",
-		UpdaterUri: "user://test/testintegrationbulkcrud",
+		CreatorUri:    "user://test/testintegrationbulkcrud",
+		UpdaterUri:    "user://test/testintegrationbulkcrud",
+		WorkflowState: "usable",
 	}
 
 	cmpDiffB := cmp.Diff(&wantMetaB, metaB.Meta,

--- a/repository/documents_api_test.go
+++ b/repository/documents_api_test.go
@@ -1801,6 +1801,109 @@ or Heads.approved_legal.Version == Status.Version`,
 		"should publish the second version now that legal has approved")
 }
 
+func TestIntegrationStatusRuleWorkflowState(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	ctx := t.Context()
+	logger := slog.New(test.NewLogHandler(t, slog.LevelInfo))
+	tc := testingAPIServer(t, logger, testingServerOptions{})
+
+	workflowClient := tc.WorkflowsClient(t,
+		itest.StandardClaims(t, "workflow_admin"))
+
+	_, err := workflowClient.SetWorkflow(ctx, &repository.SetWorkflowRequest{
+		Type: "core/article",
+		Workflow: &repository.DocumentWorkflow{
+			StepZero:           "draft",
+			Checkpoint:         "usable",
+			NegativeCheckpoint: "unpublished",
+			Steps:              []string{"draft", "done"},
+		},
+	})
+	test.Must(t, err, "create article workflow")
+
+	const ruleName = "unpublish-requires-prior-publish"
+
+	_, err = workflowClient.CreateStatusRule(ctx, &repository.CreateStatusRuleRequest{
+		Rule: &repository.StatusRule{
+			Type:        "core/article",
+			Name:        ruleName,
+			Description: "Unpublish is only allowed when previously published",
+			Expression: `Status.Version != -1
+or WorkflowState.LastCheckpoint == "usable"`,
+			AppliesTo: []string{"usable"},
+		},
+	})
+	test.Must(t, err, "create unpublish rule")
+
+	// Wait until the workflow provider picks up the rule.
+	t0 := time.Now()
+	workflowDeadline := time.After(2 * time.Second)
+
+	for {
+		if tc.WorkflowProvider.HasStatusRule("core/article", ruleName) {
+			t.Logf("had to wait %v for workflow update",
+				time.Since(t0))
+
+			break
+		}
+
+		select {
+		case <-workflowDeadline:
+			t.Fatal("workflow rule didn't propagate in time")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	client := tc.DocumentsClient(t,
+		itest.StandardClaims(t, "doc_read doc_write doc_delete"))
+
+	const (
+		docUUID = "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5"
+		docURI  = "article://test/123"
+	)
+
+	doc := baseDocument(docUUID, docURI)
+
+	res, err := client.Update(ctx, &repository.UpdateRequest{
+		Uuid:     docUUID,
+		Document: doc,
+	})
+	test.Must(t, err, "create article")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Status: []*repository.StatusUpdate{
+			{Name: "usable", Version: -1},
+		},
+	})
+	test.MustNot(t, err,
+		"unpublish before publish should be blocked by workflow rule")
+
+	if !strings.Contains(err.Error(), ruleName) {
+		t.Fatalf("error message should mention %q, got: %s",
+			ruleName, err.Error())
+	}
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Status: []*repository.StatusUpdate{
+			{Name: "usable", Version: res.Version},
+		},
+	})
+	test.Must(t, err, "publish the document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Status: []*repository.StatusUpdate{
+			{Name: "usable", Version: -1},
+		},
+	})
+	test.Must(t, err, "unpublish after publish is allowed")
+}
+
 func TestIntegrationACL(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -39,6 +39,12 @@ type PGDocStoreOptions struct {
 	DeleteTimeout      time.Duration
 	TypeConfigurations *TypeConfigurations
 	DefaultTZ          *time.Location
+	// EmitWorkflowEvent re-enables the separate "workflow" outbox event
+	// alongside the workflow_state/workflow_checkpoint fields that are
+	// folded onto the triggering document or status event. Intended as a
+	// transition aid for consumers that still depend on the standalone
+	// event; expected to be removed in a future release.
+	EmitWorkflowEvent bool
 }
 
 func NewPGDocStore(
@@ -2354,8 +2360,9 @@ func (s *PGDocStore) Update(
 
 		// The workflow state is persisted once per update with the final
 		// state; the matching transition is folded onto the document or
-		// status event that caused it above. No separate workflow event is
-		// emitted.
+		// status event that caused it above. The separate workflow event
+		// is only emitted when EmitWorkflowEvent is set, to ease the
+		// transition of consumers that still depend on it.
 		if trackWorkflow && (initialCreate || !wState.Equal(startWState)) {
 			err := q.ChangeWorkflowState(ctx,
 				postgres.ChangeWorkflowStateParams{
@@ -2372,6 +2379,26 @@ func (s *PGDocStore) Update(
 				})
 			if err != nil {
 				return nil, fmt.Errorf("update workflow state: %w", err)
+			}
+
+			if s.opts.EmitWorkflowEvent {
+				evts = append(evts, postgres.OutboxEvent{
+					Event:              string(TypeWorkflow),
+					UUID:               state.Request.UUID,
+					Nonce:              state.Nonce,
+					Version:            state.Version,
+					Timestamp:          state.Created,
+					Updater:            state.Creator,
+					Type:               state.Type,
+					Language:           state.Language,
+					MainDocument:       state.Request.MainDocument,
+					MainDocumentType:   state.MainDocType,
+					WorkflowStep:       wState.Step,
+					WorkflowCheckpoint: wState.LastCheckpoint,
+					SystemState:        state.SystemState,
+					Timespans:          TimespansAsTuples(state.Timespans),
+					Labels:             state.Labels,
+				})
 			}
 		}
 	}

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -2186,8 +2186,9 @@ func (s *PGDocStore) Update(
 			}
 
 			input, err := s.buildStatusRuleInput(
-				ctx, q, state.Request.UUID, stat.Name, status,
-				state.DocumentUpdate, state.Doc, state.Request.Meta, statusHeads,
+				ctx, q, state.Request.UUID, state.Type, stat.Name, status,
+				state.DocumentUpdate, state.Doc, state.Request.Meta,
+				statusHeads, wState,
 			)
 			if err != nil {
 				return nil, err
@@ -3038,14 +3039,16 @@ func newUpdateState(req *UpdateRequest) (*docUpdateState, error) {
 
 func (s *PGDocStore) buildStatusRuleInput(
 	ctx context.Context, q *postgres.Queries,
-	uuid uuid.UUID, name string, status Status, up DocumentUpdate,
-	d *newsdoc.Document, versionMeta newsdoc.DataMap, statusHeads map[string]StatusHead,
+	uuid uuid.UUID, docType string, name string, status Status,
+	up DocumentUpdate, d *newsdoc.Document, versionMeta newsdoc.DataMap,
+	statusHeads map[string]StatusHead, wState WorkflowState,
 ) (StatusRuleInput, error) {
 	input := StatusRuleInput{
-		Name:   name,
-		Status: status,
-		Update: up,
-		Heads:  statusHeads,
+		Name:          name,
+		Status:        status,
+		Update:        up,
+		Heads:         statusHeads,
+		WorkflowState: wState,
 	}
 
 	auth, ok := elephantine.GetAuthInfo(ctx)
@@ -3069,6 +3072,13 @@ func (s *PGDocStore) buildStatusRuleInput(
 
 		input.VersionMeta = meta
 		input.Document = *d
+	}
+
+	// Make sure the document type is available even when no concrete
+	// version is loaded (e.g. unpublish requests with status version -1).
+	// EvaluateRules matches rules by Document.Type.
+	if input.Document.Type == "" {
+		input.Document.Type = docType
 	}
 
 	return input, nil

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -2009,6 +2009,7 @@ func (s *PGDocStore) Update(
 		)
 
 		workflow, hasWorkflow := workflows.GetDocumentWorkflow(state.Type)
+		trackWorkflow := hasWorkflow && !state.IsMetaDoc
 
 		if hasWorkflow {
 			s, err := loadWorkflowState(ctx, q, workflow, state.UUID)
@@ -2104,11 +2105,21 @@ func (s *PGDocStore) Update(
 
 			// Queue up the document version event for the eventlog.
 			evts = append(evts, evt)
+			docEvtIdx := len(evts) - 1
 
 			// Progress workflow state.
+			preState := wState
 			wState = workflow.Step(wState, WorkflowStep{
 				Version: version,
 			})
+
+			// Fold workflow state onto the document event when the
+			// version bump either creates the workflow record or
+			// resets the step via a checkpoint.
+			if trackWorkflow && (initialCreate || !wState.Equal(preState)) {
+				evts[docEvtIdx].WorkflowStep = wState.Step
+				evts[docEvtIdx].WorkflowCheckpoint = wState.LastCheckpoint
+			}
 		}
 
 		var metaDocVersion int64
@@ -2278,6 +2289,8 @@ func (s *PGDocStore) Update(
 				Labels:           state.Labels,
 			})
 
+			statusEvtIdx := len(evts) - 1
+
 			// Progress workflow state
 			oldState := wState
 			wState = workflow.Step(wState, WorkflowStep{
@@ -2289,6 +2302,11 @@ func (s *PGDocStore) Update(
 			if !wState.Equal(oldState) {
 				lastStatusName = pointer(stat.Name)
 				lastStatusID = pointer(status.ID)
+
+				if trackWorkflow {
+					evts[statusEvtIdx].WorkflowStep = wState.Step
+					evts[statusEvtIdx].WorkflowCheckpoint = wState.LastCheckpoint
+				}
 			}
 		}
 
@@ -2333,7 +2351,11 @@ func (s *PGDocStore) Update(
 			})
 		}
 
-		if !state.IsMetaDoc && hasWorkflow && (initialCreate || !wState.Equal(startWState)) {
+		// The workflow state is persisted once per update with the final
+		// state; the matching transition is folded onto the document or
+		// status event that caused it above. No separate workflow event is
+		// emitted.
+		if trackWorkflow && (initialCreate || !wState.Equal(startWState)) {
 			err := q.ChangeWorkflowState(ctx,
 				postgres.ChangeWorkflowStateParams{
 					UUID:            state.UUID,
@@ -2350,26 +2372,6 @@ func (s *PGDocStore) Update(
 			if err != nil {
 				return nil, fmt.Errorf("update workflow state: %w", err)
 			}
-
-			// Queue up the event for the workflow update.
-			evts = append(evts, postgres.OutboxEvent{
-				Event:              string(TypeWorkflow),
-				UUID:               state.Request.UUID,
-				Nonce:              state.Nonce,
-				Version:            state.Version,
-				Timestamp:          state.Created,
-				Updater:            state.Creator,
-				Type:               state.Type,
-				Language:           state.Language,
-				MainDocument:       state.Request.MainDocument,
-				MainDocumentType:   state.MainDocType,
-				WorkflowStep:       wState.Step,
-				WorkflowCheckpoint: wState.LastCheckpoint,
-				// TODO: previous step?
-				SystemState: state.SystemState,
-				Timespans:   TimespansAsTuples(state.Timespans),
-				Labels:      state.Labels,
-			})
 		}
 	}
 

--- a/repository/socket_test.go
+++ b/repository/socket_test.go
@@ -172,10 +172,11 @@ func TestIntegrationSocket(t *testing.T) {
 	status, err := resp.AwaitDocumentStatus(subCall, lossUUID, "usable", 1, 2*time.Second)
 	test.Must(t, err, "get loss article status message")
 
-	workflow, err := resp.AwaitWorkflowState(subCall, lossUUID, "usable", 2*time.Second)
-	test.Must(t, err, "get loss article workflow message")
+	test.Equal(t, "usable",
+		status.DocumentUpdate.Event.WorkflowState,
+		"workflow state is folded into the loss article status event")
 
-	keyResp = append(keyResp, status, workflow)
+	keyResp = append(keyResp, status)
 
 	beachPlanUUID := writeDoc(t, client, docsDir, "beach_plan_v1", nil)
 
@@ -209,10 +210,11 @@ func TestIntegrationSocket(t *testing.T) {
 	beachStatus, err := resp.AwaitDocumentStatus(subCall, beachUUID, "usable", 1, 2*time.Second)
 	test.Must(t, err, "get beach article status message")
 
-	beachWorkflow, err := resp.AwaitWorkflowState(subCall, beachUUID, "usable", 2*time.Second)
-	test.Must(t, err, "get beach article workflow message")
+	test.Equal(t, "usable",
+		beachStatus.DocumentUpdate.Event.WorkflowState,
+		"workflow state is folded into the beach article status event")
 
-	keyResp = append(keyResp, beachStatus, beachWorkflow)
+	keyResp = append(keyResp, beachStatus)
 
 	// Move the beach planning out of time range
 	writeDoc(t, client, docsDir, "beach_plan_v3", nil)
@@ -818,27 +820,6 @@ func (rc *responseCollection) AwaitDocumentStatus(
 
 		return evt.Event == "status" && evt.Uuid == docUUID &&
 			evt.Status == status && evt.StatusId == id
-	}, timeout)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
-}
-
-func (rc *responseCollection) AwaitWorkflowState(
-	callID string,
-	docUUID string, state string,
-	timeout time.Duration,
-) (*repositorysocket.Response, error) {
-	resp, err := rc.AwaitResponse(callID, func(resp *repositorysocket.Response) bool {
-		if resp.DocumentUpdate == nil || resp.DocumentUpdate.Event == nil {
-			return false
-		}
-
-		evt := resp.DocumentUpdate.Event
-
-		return evt.Event == "workflow" && evt.Uuid == docUUID && evt.WorkflowState == state
 	}, timeout)
 	if err != nil {
 		return nil, err

--- a/repository/testdata/TestIntegrationDocumentLanguage/eventlog.json
+++ b/repository/testdata/TestIntegrationDocumentLanguage/eventlog.json
@@ -70,6 +70,7 @@
       "updater_uri": "user://test/testintegrationdocumentlanguage",
       "type": "core/article",
       "language": "en-gb",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {

--- a/repository/testdata/TestIntegrationStatus/eventlog.json
+++ b/repository/testdata/TestIntegrationStatus/eventlog.json
@@ -55,6 +55,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -68,6 +69,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -81,6 +83,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -94,6 +97,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -107,6 +111,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -120,6 +125,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -145,6 +151,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -158,6 +165,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -171,6 +179,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -184,6 +193,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -197,6 +207,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -210,6 +221,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -235,6 +247,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -248,6 +261,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -261,6 +275,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -274,6 +289,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -287,6 +303,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -300,6 +317,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -325,6 +343,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -338,6 +357,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -351,6 +371,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -364,6 +385,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -377,6 +399,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -390,6 +413,7 @@
       "updater_uri": "user://test/testintegrationstatus",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {

--- a/repository/testdata/TestIntegrationWorkflows/events.json
+++ b/repository/testdata/TestIntegrationWorkflows/events.json
@@ -9,6 +9,7 @@
       "updater_uri": "user://test/testintegrationworkflows",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "draft",
       "document_nonce": "00000000-0000-0000-0000-000000000000",
       "schema_generation": "1"
     },
@@ -34,18 +35,6 @@
     },
     {
       "id": "3",
-      "event": "workflow",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "1",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "workflow_state": "draft",
-      "document_nonce": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-      "id": "4",
       "event": "status",
       "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
       "timestamp": "2023-01-10T20:06:37+01:00",
@@ -55,18 +44,33 @@
       "updater_uri": "user://test/testintegrationworkflows",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
-      "id": "5",
-      "event": "workflow",
+      "id": "4",
+      "event": "document",
       "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
       "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "1",
+      "version": "2",
       "updater_uri": "user://test/testintegrationworkflows",
       "type": "core/article",
       "language": "en",
-      "workflow_state": "done",
+      "document_nonce": "00000000-0000-0000-0000-000000000000",
+      "schema_generation": "1"
+    },
+    {
+      "id": "5",
+      "event": "status",
+      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
+      "timestamp": "2023-01-10T20:06:37+01:00",
+      "version": "2",
+      "status": "approved",
+      "status_id": "1",
+      "updater_uri": "user://test/testintegrationworkflows",
+      "type": "core/article",
+      "language": "en",
+      "workflow_state": "approved",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -74,7 +78,7 @@
       "event": "document",
       "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
       "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "2",
+      "version": "3",
       "updater_uri": "user://test/testintegrationworkflows",
       "type": "core/article",
       "language": "en",
@@ -86,57 +90,9 @@
       "event": "status",
       "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
       "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "2",
-      "status": "approved",
-      "status_id": "1",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "document_nonce": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-      "id": "8",
-      "event": "workflow",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "2",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "workflow_state": "approved",
-      "document_nonce": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-      "id": "9",
-      "event": "document",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "3",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "document_nonce": "00000000-0000-0000-0000-000000000000",
-      "schema_generation": "1"
-    },
-    {
-      "id": "10",
-      "event": "status",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
       "version": "3",
       "status": "usable",
       "status_id": "1",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "document_nonce": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-      "id": "11",
-      "event": "workflow",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "3",
       "updater_uri": "user://test/testintegrationworkflows",
       "type": "core/article",
       "language": "en",
@@ -145,20 +101,8 @@
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
-      "id": "12",
+      "id": "8",
       "event": "document",
-      "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
-      "timestamp": "2023-01-10T20:06:37+01:00",
-      "version": "4",
-      "updater_uri": "user://test/testintegrationworkflows",
-      "type": "core/article",
-      "language": "en",
-      "document_nonce": "00000000-0000-0000-0000-000000000000",
-      "schema_generation": "1"
-    },
-    {
-      "id": "13",
-      "event": "workflow",
       "uuid": "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5",
       "timestamp": "2023-01-10T20:06:37+01:00",
       "version": "4",
@@ -167,7 +111,8 @@
       "language": "en",
       "workflow_state": "draft",
       "workflow_checkpoint": "usable",
-      "document_nonce": "00000000-0000-0000-0000-000000000000"
+      "document_nonce": "00000000-0000-0000-0000-000000000000",
+      "schema_generation": "1"
     }
   ]
 }

--- a/repository/workflow_api.go
+++ b/repository/workflow_api.go
@@ -275,16 +275,14 @@ func (s *WorkflowsService) SetWorkflow(
 		return nil, twirp.RequiredArgumentError("workflow")
 	}
 
-	if req.Workflow.StepZero == "" {
-		return nil, twirp.RequiredArgumentError("workflow.step_zero")
-	}
-
-	if req.Workflow.Checkpoint == "" {
-		return nil, twirp.RequiredArgumentError("workflow.checkpoint")
-	}
-
-	if req.Workflow.NegativeCheckpoint == "" {
-		return nil, twirp.RequiredArgumentError("workflow.negative_checkpoint")
+	// Checkpoints and step zero are optional. A workflow without a
+	// checkpoint behaves like the implicit workflow: every listed step is a
+	// regular transition and no positive/negative checkpoint state is
+	// recorded.
+	if req.Workflow.Checkpoint == "" && req.Workflow.NegativeCheckpoint != "" {
+		return nil, twirp.InvalidArgumentError(
+			"workflow.checkpoint",
+			"required when negative_checkpoint is set")
 	}
 
 	err = s.store.SetDocumentWorkflow(ctx, DocumentWorkflow{

--- a/repository/workflows.go
+++ b/repository/workflows.go
@@ -186,18 +186,37 @@ func (w *Workflows) HasStatus(docType string, name string) bool {
 	return ok && !status.Disabled
 }
 
+// HasStatusRule reports whether a status rule with the given name is currently
+// loaded for the document type. It is primarily intended for tests that need
+// to wait for a rule to propagate from the database to the provider.
+func (w *Workflows) HasStatusRule(docType string, name string) bool {
+	w.m.RLock()
+	defer w.m.RUnlock()
+
+	for _, rules := range w.rules {
+		for _, r := range rules {
+			if r.Type == docType && r.Name == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func typeScopedKey(docType string, name string) string {
 	return docType + ":" + name
 }
 
 type StatusRuleInput struct {
-	Name        string
-	Status      Status
-	Update      DocumentUpdate
-	Document    newsdoc.Document
-	VersionMeta newsdoc.DataMap
-	Heads       map[string]StatusHead
-	User        elephantine.JWTClaims
+	Name          string
+	Status        Status
+	Update        DocumentUpdate
+	Document      newsdoc.Document
+	VersionMeta   newsdoc.DataMap
+	Heads         map[string]StatusHead
+	User          elephantine.JWTClaims
+	WorkflowState WorkflowState
 }
 
 type StatusRuleViolation struct {

--- a/repository/workflows.go
+++ b/repository/workflows.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Workflows struct {
-	m         sync.RWMutex
-	vm        vm.VM
-	statuses  map[string]DocumentStatus
-	rules     map[string][]compiledRule
-	workflows map[string]DocumentWorkflow
+	m            sync.RWMutex
+	vm           vm.VM
+	statuses     map[string]DocumentStatus
+	typeStatuses map[string][]string
+	rules        map[string][]compiledRule
+	workflows    map[string]DocumentWorkflow
 }
 
 type WorkflowLoader interface {
@@ -82,10 +83,18 @@ func (w *Workflows) loadWorkflows(
 	}
 
 	statusMap := make(map[string]DocumentStatus)
+	typeStatuses := make(map[string][]string)
 
 	for i := range statuses {
 		key := typeScopedKey(statuses[i].Type, statuses[i].Name)
 		statusMap[key] = statuses[i]
+
+		if statuses[i].Disabled {
+			continue
+		}
+
+		typeStatuses[statuses[i].Type] = append(
+			typeStatuses[statuses[i].Type], statuses[i].Name)
 	}
 
 	rules, err := loader.GetStatusRules(ctx)
@@ -130,6 +139,7 @@ func (w *Workflows) loadWorkflows(
 
 	w.m.Lock()
 	w.statuses = statusMap
+	w.typeStatuses = typeStatuses
 	w.rules = ruleMap
 	w.workflows = workflowMap
 	w.m.Unlock()
@@ -137,12 +147,33 @@ func (w *Workflows) loadWorkflows(
 	return nil
 }
 
+// GetDocumentWorkflow returns the workflow for a document type. If no explicit
+// workflow has been configured an implicit workflow is synthesised from the
+// type's configured statuses: no checkpoint, all statuses accepted as steps.
+// Returns false only when the type has neither an explicit workflow nor any
+// configured statuses.
 func (w *Workflows) GetDocumentWorkflow(docType string) (DocumentWorkflow, bool) {
 	w.m.RLock()
-	wf, ok := w.workflows[docType]
-	w.m.RUnlock()
+	defer w.m.RUnlock()
 
-	return wf, ok
+	if wf, ok := w.workflows[docType]; ok {
+		return wf, true
+	}
+
+	steps := w.typeStatuses[docType]
+	if len(steps) == 0 {
+		return DocumentWorkflow{}, false
+	}
+
+	stepsCopy := make([]string, len(steps))
+	copy(stepsCopy, steps)
+
+	return DocumentWorkflow{
+		Type: docType,
+		Configuration: DocumentWorkflowConfiguration{
+			Steps: stepsCopy,
+		},
+	}, true
 }
 
 func (w *Workflows) HasStatus(docType string, name string) bool {

--- a/repository/workflows_test.go
+++ b/repository/workflows_test.go
@@ -2,16 +2,208 @@ package repository_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/ttab/elephant-api/repository"
 	"github.com/ttab/elephant-repository/internal"
 	itest "github.com/ttab/elephant-repository/internal/test"
+	repo "github.com/ttab/elephant-repository/repository"
 	"github.com/ttab/elephantine/test"
 )
+
+type stubWorkflowLoader struct {
+	statuses  []repo.DocumentStatus
+	workflows []repo.DocumentWorkflow
+}
+
+func (l *stubWorkflowLoader) GetStatuses(
+	_ context.Context, docType string,
+) ([]repo.DocumentStatus, error) {
+	if docType == "" {
+		return l.statuses, nil
+	}
+
+	var matching []repo.DocumentStatus
+
+	for _, s := range l.statuses {
+		if s.Type == docType {
+			matching = append(matching, s)
+		}
+	}
+
+	return matching, nil
+}
+
+func (l *stubWorkflowLoader) GetStatusRules(
+	_ context.Context,
+) ([]repo.StatusRule, error) {
+	return nil, nil
+}
+
+func (l *stubWorkflowLoader) SetDocumentWorkflow(
+	_ context.Context, _ repo.DocumentWorkflow,
+) error {
+	return errors.New("not implemented")
+}
+
+func (l *stubWorkflowLoader) GetDocumentWorkflows(
+	_ context.Context,
+) ([]repo.DocumentWorkflow, error) {
+	return l.workflows, nil
+}
+
+func (l *stubWorkflowLoader) GetDocumentWorkflow(
+	_ context.Context, docType string,
+) (repo.DocumentWorkflow, error) {
+	for _, wf := range l.workflows {
+		if wf.Type == docType {
+			return wf, nil
+		}
+	}
+
+	return repo.DocumentWorkflow{}, errors.New("not found")
+}
+
+func (l *stubWorkflowLoader) DeleteDocumentWorkflow(
+	_ context.Context, _ string,
+) error {
+	return errors.New("not implemented")
+}
+
+func (l *stubWorkflowLoader) OnWorkflowUpdate(
+	_ context.Context, _ chan repo.WorkflowEvent,
+) {
+}
+
+func TestImplicitWorkflow(t *testing.T) {
+	t.Parallel()
+
+	loader := &stubWorkflowLoader{
+		statuses: []repo.DocumentStatus{
+			{Type: "core/article", Name: "draft"},
+			{Type: "core/article", Name: "done"},
+			{Type: "core/article", Name: "usable"},
+			{Type: "core/article", Name: "retired", Disabled: true},
+			{Type: "core/image", Name: "usable"},
+		},
+		workflows: []repo.DocumentWorkflow{
+			{
+				Type: "core/article-with-explicit",
+				Configuration: repo.DocumentWorkflowConfiguration{
+					StepZero:           "draft",
+					Checkpoint:         "usable",
+					NegativeCheckpoint: "unpublished",
+					Steps:              []string{"draft", "done"},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	workflows, err := repo.NewWorkflows(ctx,
+		slog.New(test.NewLogHandler(t, slog.LevelInfo)), loader)
+	test.Must(t, err, "build workflows")
+
+	t.Run("implicit workflow with multiple statuses", func(t *testing.T) {
+		wf, ok := workflows.GetDocumentWorkflow("core/article")
+		test.Equal(t, true, ok,
+			"implicit workflow should exist for type with statuses")
+		test.Equal(t, "core/article", wf.Type, "workflow type")
+		test.Equal(t, "", wf.Configuration.Checkpoint,
+			"implicit workflow has no checkpoint")
+		test.Equal(t, "", wf.Configuration.NegativeCheckpoint,
+			"implicit workflow has no negative checkpoint")
+		test.Equal(t, "", wf.Configuration.StepZero,
+			"implicit workflow has no step zero")
+
+		expected := []string{"draft", "done", "usable"}
+		got := slices.Clone(wf.Configuration.Steps)
+		slices.Sort(got)
+		slices.Sort(expected)
+
+		test.EqualDiff(t, expected, got,
+			"implicit workflow steps mirror configured statuses (disabled excluded)")
+	})
+
+	t.Run("implicit workflow with single status", func(t *testing.T) {
+		wf, ok := workflows.GetDocumentWorkflow("core/image")
+		test.Equal(t, true, ok, "implicit workflow should exist")
+		test.EqualDiff(t, []string{"usable"}, wf.Configuration.Steps,
+			"single status becomes the only step")
+	})
+
+	t.Run("no implicit workflow when no statuses configured", func(t *testing.T) {
+		_, ok := workflows.GetDocumentWorkflow("core/unknown")
+		test.Equal(t, false, ok,
+			"types without statuses get no workflow")
+	})
+
+	t.Run("explicit workflow takes precedence", func(t *testing.T) {
+		wf, ok := workflows.GetDocumentWorkflow("core/article-with-explicit")
+		test.Equal(t, true, ok, "explicit workflow should exist")
+		test.Equal(t, "usable", wf.Configuration.Checkpoint,
+			"explicit workflow keeps its checkpoint")
+		test.EqualDiff(t, []string{"draft", "done"}, wf.Configuration.Steps,
+			"explicit steps are preserved")
+	})
+
+	t.Run("implicit workflow steps drive state transitions", func(t *testing.T) {
+		wf, ok := workflows.GetDocumentWorkflow("core/article")
+		test.Equal(t, true, ok, "implicit workflow exists")
+
+		state := wf.Start()
+		test.Equal(t, "", state.Step, "start step is empty for implicit workflow")
+
+		state = wf.Step(state, repo.WorkflowStep{
+			Status: &repo.StatusUpdate{Name: "done", Version: 1},
+		})
+		test.Equal(t, "done", state.Step,
+			"status transitions advance implicit step")
+
+		state = wf.Step(state, repo.WorkflowStep{
+			Status: &repo.StatusUpdate{Name: "usable", Version: 1},
+		})
+		test.Equal(t, "usable", state.Step,
+			"every configured status counts as a step")
+		test.Equal(t, "", state.LastCheckpoint,
+			"implicit workflow never records a checkpoint")
+
+		// A new version with no checkpoint configured must not reset
+		// the recorded step back to empty.
+		state = wf.Step(state, repo.WorkflowStep{Version: 2})
+		test.Equal(t, "usable", state.Step,
+			"version bumps don't reset step when no checkpoint is configured")
+	})
+
+	t.Run("explicit workflow without checkpoint", func(t *testing.T) {
+		wf := repo.DocumentWorkflow{
+			Type: "core/note",
+			Configuration: repo.DocumentWorkflowConfiguration{
+				Steps: []string{"draft", "done"},
+			},
+		}
+
+		state := wf.Start()
+		state = wf.Step(state, repo.WorkflowStep{
+			Status: &repo.StatusUpdate{Name: "done", Version: 1},
+		})
+		test.Equal(t, "done", state.Step,
+			"explicit workflow without checkpoint advances step")
+		test.Equal(t, "", state.LastCheckpoint,
+			"checkpoint-less workflow does not record a checkpoint")
+
+		state = wf.Step(state, repo.WorkflowStep{Version: 2})
+		test.Equal(t, "done", state.Step,
+			"version bumps don't reset step without a checkpoint")
+	})
+}
 
 func TestIntegrationWorkflows(t *testing.T) {
 	if testing.Short() {
@@ -111,7 +303,7 @@ func TestIntegrationWorkflows(t *testing.T) {
 	})
 	test.Must(t, err, "update article after usable")
 
-	events := collectEventlog(t, client, 13, 5*time.Second)
+	events := collectEventlog(t, client, 8, 5*time.Second)
 	eventsGolden := filepath.Join("testdata", t.Name(), "events.json")
 
 	test.TestMessageAgainstGolden(t, regenerate, events, eventsGolden,

--- a/repository/workflows_test.go
+++ b/repository/workflows_test.go
@@ -322,6 +322,104 @@ func TestIntegrationWorkflows(t *testing.T) {
 		ignoreUUIDField("nonce"))
 }
 
+func TestIntegrationWorkflowEventEmission(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	t.Parallel()
+
+	logger := slog.New(test.NewLogHandler(t, slog.LevelInfo))
+
+	tc := testingAPIServer(t, logger, testingServerOptions{
+		RunEventlogBuilder: true,
+		EmitWorkflowEvent:  true,
+	})
+
+	client := tc.DocumentsClient(t,
+		itest.StandardClaims(t, "doc_read doc_write doc_delete eventlog_read"))
+	wflowClient := tc.WorkflowsClient(t,
+		itest.StandardClaims(t, "workflow_admin"))
+
+	ctx := t.Context()
+
+	_, err := wflowClient.SetWorkflow(ctx, &repository.SetWorkflowRequest{
+		Type: "core/article",
+		Workflow: &repository.DocumentWorkflow{
+			StepZero:           "draft",
+			Checkpoint:         "usable",
+			NegativeCheckpoint: "unpublished",
+			Steps:              []string{"draft", "done"},
+		},
+	})
+	test.Must(t, err, "create workflow")
+
+	waitDeadline := time.Now().Add(2 * time.Second)
+
+	for {
+		if time.Now().After(waitDeadline) {
+			t.Fatal("timed out waiting for workflow to propagate")
+		}
+
+		wf, ok := tc.WorkflowProvider.GetDocumentWorkflow("core/article")
+		if ok && wf.Configuration.Checkpoint == "usable" {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	const (
+		docUUID = "ffa05627-be7a-4f09-8bfc-bc3361b0b0b5"
+		docURI  = "article://test/123"
+	)
+
+	doc := baseDocument(docUUID, docURI)
+
+	res, err := client.Update(ctx, &repository.UpdateRequest{
+		Uuid:     docUUID,
+		Document: doc,
+	})
+	test.Must(t, err, "create article")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Status: []*repository.StatusUpdate{
+			{Name: "usable", Version: res.Version},
+		},
+	})
+	test.Must(t, err, "set usable status")
+
+	// doc + ACL + doc-workflow + status + status-workflow = 5 events.
+	events := collectEventlog(t, client, 5, 5*time.Second)
+
+	var (
+		workflowEvents []*repository.EventlogItem
+		statusEvent    *repository.EventlogItem
+	)
+
+	for _, e := range events.Items {
+		switch e.Event {
+		case "workflow":
+			workflowEvents = append(workflowEvents, e)
+		case "status":
+			statusEvent = e
+		}
+	}
+
+	test.Equal(t, 2, len(workflowEvents),
+		"flag re-enables the standalone workflow events")
+
+	if statusEvent == nil {
+		t.Fatal("expected a status event")
+	}
+
+	test.Equal(t, "usable", statusEvent.WorkflowState,
+		"workflow state is still folded onto the status event")
+	test.Equal(t, "usable", statusEvent.WorkflowCheckpoint,
+		"workflow checkpoint is still folded onto the status event")
+}
+
 func collectEventlog(
 	t *testing.T, client repository.Documents,
 	minCount int, timeout time.Duration,

--- a/testdata/TestDeleteRestore/eventlog.json
+++ b/testdata/TestDeleteRestore/eventlog.json
@@ -112,6 +112,7 @@
       "updater_uri": "user://test/testdeleterestore",
       "type": "core/article",
       "language": "en-gb",
+      "workflow_state": "done",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {
@@ -125,6 +126,7 @@
       "updater_uri": "user://test/testdeleterestore",
       "type": "core/article",
       "language": "en-gb",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {

--- a/testdata/TestDocumentsServiceMetaDocuments/eventlog.json
+++ b/testdata/TestDocumentsServiceMetaDocuments/eventlog.json
@@ -89,6 +89,7 @@
       "updater_uri": "user://test/testdocumentsservicemetadocuments",
       "type": "core/article",
       "language": "en",
+      "workflow_state": "usable",
       "document_nonce": "00000000-0000-0000-0000-000000000000"
     },
     {

--- a/testdata/TestIntegrationSocket/messages.json
+++ b/testdata/TestIntegrationSocket/messages.json
@@ -26,6 +26,7 @@
                 ]
               }
             ],
+            "workflow_state": "usable",
             "creator_uri": "user://test/testintegrationsocket",
             "updater_uri": "user://test/testintegrationsocket",
             "nonce": "00000000-0000-0000-0000-000000000000",
@@ -149,37 +150,13 @@
     "document_update": {
       "set_name": "planning",
       "event": {
-        "id": "8",
+        "id": "7",
         "event": "status",
         "uuid": "f7eb1d2d-0814-4027-b857-fa21d2f16805",
         "timestamp": "2023-01-10T20:06:37+01:00",
         "version": "1",
         "status": "usable",
         "status_id": "1",
-        "updater_uri": "user://test/testintegrationsocket",
-        "type": "core/article",
-        "language": "sv-se",
-        "document_nonce": "00000000-0000-0000-0000-000000000000",
-        "timespans": [
-          {
-            "from": "2025-11-14T05:53:05Z",
-            "to": "2025-11-14T05:53:05Z"
-          }
-        ]
-      },
-      "included": true
-    }
-  },
-  {
-    "call_id": "d063e44a-866c-47c5-9ba5-f10bffd753ed",
-    "document_update": {
-      "set_name": "planning",
-      "event": {
-        "id": "9",
-        "event": "workflow",
-        "uuid": "f7eb1d2d-0814-4027-b857-fa21d2f16805",
-        "timestamp": "2023-01-10T20:06:37+01:00",
-        "version": "1",
         "updater_uri": "user://test/testintegrationsocket",
         "type": "core/article",
         "language": "sv-se",
@@ -201,7 +178,7 @@
     "document_update": {
       "set_name": "planning",
       "event": {
-        "id": "10",
+        "id": "8",
         "event": "document",
         "uuid": "a9791252-6e7a-40b2-bc0b-129d25df17b8",
         "timestamp": "2023-01-10T20:06:37+01:00",
@@ -316,7 +293,7 @@
     "document_update": {
       "set_name": "planning",
       "event": {
-        "id": "15",
+        "id": "12",
         "event": "document",
         "uuid": "a9791252-6e7a-40b2-bc0b-129d25df17b8",
         "timestamp": "2023-01-10T20:06:37+01:00",
@@ -469,37 +446,13 @@
     "document_update": {
       "set_name": "planning",
       "event": {
-        "id": "16",
+        "id": "13",
         "event": "status",
         "uuid": "85428a43-963e-443b-9700-9fdb5dfcb437",
         "timestamp": "2023-01-10T20:06:37+01:00",
         "version": "1",
         "status": "usable",
         "status_id": "1",
-        "updater_uri": "user://test/testintegrationsocket",
-        "type": "core/article",
-        "language": "sv-se",
-        "document_nonce": "00000000-0000-0000-0000-000000000000",
-        "timespans": [
-          {
-            "from": "2025-11-14T12:34:52Z",
-            "to": "2025-11-14T12:34:52Z"
-          }
-        ]
-      },
-      "included": true
-    }
-  },
-  {
-    "call_id": "d063e44a-866c-47c5-9ba5-f10bffd753ed",
-    "document_update": {
-      "set_name": "planning",
-      "event": {
-        "id": "17",
-        "event": "workflow",
-        "uuid": "85428a43-963e-443b-9700-9fdb5dfcb437",
-        "timestamp": "2023-01-10T20:06:37+01:00",
-        "version": "1",
         "updater_uri": "user://test/testintegrationsocket",
         "type": "core/article",
         "language": "sv-se",

--- a/testdata/TestIntegrationSocketEventlog/messages.json
+++ b/testdata/TestIntegrationSocketEventlog/messages.json
@@ -76,6 +76,7 @@
             "updater_uri": "user://test/testintegrationsocketeventlog",
             "type": "core/article",
             "language": "sv-se",
+            "workflow_state": "draft",
             "document_nonce": "00000000-0000-0000-0000-000000000000",
             "schema_generation": "1"
           },
@@ -114,20 +115,6 @@
         {
           "event": {
             "id": "5",
-            "event": "workflow",
-            "uuid": "85428a43-963e-443b-9700-9fdb5dfcb437",
-            "timestamp": "2023-01-10T20:06:37+01:00",
-            "version": "1",
-            "updater_uri": "user://test/testintegrationsocketeventlog",
-            "type": "core/article",
-            "language": "sv-se",
-            "workflow_state": "draft",
-            "document_nonce": "00000000-0000-0000-0000-000000000000"
-          }
-        },
-        {
-          "event": {
-            "id": "6",
             "event": "document",
             "uuid": "a9791252-6e7a-40b2-bc0b-129d25df17b8",
             "timestamp": "2023-01-10T20:06:37+01:00",
@@ -159,7 +146,7 @@
         },
         {
           "event": {
-            "id": "7",
+            "id": "6",
             "event": "document",
             "uuid": "a9791252-6e7a-40b2-bc0b-129d25df17b8",
             "timestamp": "2023-01-10T20:06:37+01:00",

--- a/testdata/TestIntegrationStatsOverview/admin_overview.json
+++ b/testdata/TestIntegrationStatsOverview/admin_overview.json
@@ -12,6 +12,7 @@
           "created": "2023-01-10T20:06:37+01:00"
         }
       },
+      "workflow_state": "done",
       "creator_uri": "user://test/testintegrationstatsoverview",
       "updater_uri": "user://test/testintegrationstatsoverview"
     },
@@ -27,6 +28,7 @@
           "created": "2023-01-10T20:06:37+01:00"
         }
       },
+      "workflow_state": "usable",
       "creator_uri": "user://test/testintegrationstatsoverview",
       "updater_uri": "user://test/testintegrationstatsoverview"
     }

--- a/testdata/TestIntegrationStatsOverview/creator_overview.json
+++ b/testdata/TestIntegrationStatsOverview/creator_overview.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "workflow_state": "done",
       "creator_uri": "user://test/testintegrationstatsoverview",
       "updater_uri": "user://test/testintegrationstatsoverview"
     }

--- a/testdata/TestIntegrationStatsOverview/other_overview.json
+++ b/testdata/TestIntegrationStatsOverview/other_overview.json
@@ -12,6 +12,7 @@
           "created": "2023-01-10T20:06:37+01:00"
         }
       },
+      "workflow_state": "usable",
       "creator_uri": "user://test/testintegrationstatsoverview",
       "updater_uri": "user://test/testintegrationstatsoverview"
     }


### PR DESCRIPTION
Reworks document workflows so every document type with statuses participates in workflow tracking, collapses workflow events into the events that triggered them, and lets status rules inspect workflow state.

### Implicit workflow for types without an explicit workflow

`Workflows.GetDocumentWorkflow` now falls back to an implicit workflow for any document type that has at least one configured non-disabled status. The implicit workflow has no checkpoint and no step zero; every configured status is accepted as a step. Types with no statuses still return `(_, false)` — there is nothing to step through.

This means doc types that were previously invisible to workflow tracking (e.g. `core/article` without an explicit `SetWorkflow` call) now get a `workflow_state` row at first write and have their step advance as statuses are applied.

### Checkpoint and step zero are optional for explicit workflows

`SetWorkflow` no longer requires `step_zero`, `checkpoint`, or `negative_checkpoint`. The only remaining structural constraint is that `negative_checkpoint` may not be set without a `checkpoint`. `DocumentWorkflow.Step` was hardened so empty checkpoint values don't accidentally match an empty `state.Step`.

### Workflow events folded onto the triggering event

By default the separate `workflow` outbox event is no longer emitted. Instead, the `document` or `status` event that caused the workflow state to change carries `workflow_state` and `workflow_checkpoint` directly. The `workflow_state` table is still written once per update with the final state and the status that last affected it, so existing readers of that table are unchanged.

Per-event folding preserves intermediate state transitions inside a single update — if two statuses in one call advance the state in turn, both status events get their corresponding workflow fields. `TypeWorkflow` remains defined so the archiver can still consume legacy rows in the eventlog.

#### Transition flag for external consumers

A new `--emit-workflow-event` flag (env `EMIT_WORKFLOW_EVENT`, also exposed as `PGDocStoreOptions.EmitWorkflowEvent`) re-enables the standalone `workflow` outbox event alongside the folded annotations. Consumers that still depend on the separate event can opt in while they migrate to reading `workflow_state`/`workflow_checkpoint` off the triggering document/status event. The flag is intentionally temporary — it and the emission code will be removed in a future release.

### Status rules can read workflow state

`StatusRuleInput` gained a `WorkflowState` field populated with the in-flight state at the time the rule fires (before the current status's step is applied). Rules can now express checks like "only allow unpublish if previously published":

```
Status.Version != -1 or WorkflowState.LastCheckpoint == "usable"
```

`buildStatusRuleInput` also defaults `Document.Type` to the doc type when no concrete document version is loaded. Without this, rules for unpublish requests (`Status.Version == -1`) were silently skipped because `EvaluateRules` matches rules by `Document.Type` and the input had no document loaded.

### Tests and goldens

- New `TestImplicitWorkflow` unit test (no Docker required) covering implicit workflow construction, explicit precedence, the no-statuses fall-through, step transitions without a checkpoint, and version bumps with no checkpoint configured.
- New `TestIntegrationStatusRuleWorkflowState` exercising the unpublish-after-publish rule end to end.
- New `TestIntegrationWorkflowEventEmission` verifying that `EmitWorkflowEvent` re-enables the standalone `workflow` event while keeping the inline annotations.
- New `HasStatusRule(docType, name)` helper on `Workflows` so tests can wait deterministically for rule propagation. `TestContext.WorkflowProvider` is now typed as `*repository.Workflows` to expose it.
- Goldens regenerated for the affected integration tests (`TestIntegrationWorkflows`, `TestIntegrationStatus`, `TestIntegrationDocumentLanguage`, `TestIntegrationBulkCrud`, `TestIntegrationSocket*`, `TestDeleteRestore`, `TestIntegrationStatsOverview`, `TestDocumentsServiceMetaDocuments`). The diffs show separate workflow events removed and `workflow_state` annotations appearing inline on the triggering document/status events.

### Compatibility notes

- Existing `workflow` events in the eventlog are kept and still readable; by default no new ones are emitted, but operators can set `--emit-workflow-event` to keep emitting them during a transition window.
- `GetWorkflow` (Twirp) still returns 404 for doc types without an explicitly configured workflow — implicit workflows are an internal concept and aren't surfaced through the management API.
- Doc types that previously had no statuses configured behave identically. Doc types with statuses now get a `workflow_state` row on first write.
