### PR TITLE
fix: lock cleaner sweeps locks expired >5m ago, not those expiring <5m from now

### DIFF
--- a/repository/lock_cleaner.go
+++ b/repository/lock_cleaner.go
@@ -46,7 +46,18 @@ func (s *PGDocStore) RunCleaner(ctx context.Context, period time.Duration) {
 func (s *PGDocStore) removeExpiredLocks(ctx context.Context) error {
 	s.logger.Debug("removing expired document locks")
 
-	cutoff := pg.Time(time.Now().Add(5 * time.Minute))
+	// Cutoff lags `now` by 5m so the cleaner only sweeps locks that
+	// have already been expired for at least that long. Request
+	// handlers filter live-lock reads on `l.expires > now`, so an
+	// expired row is already invisible to writers; the cleaner is
+	// the janitor that reclaims the storage after a grace period.
+	//
+	// The previous value was `now + 5m`, which inverted the intent
+	// and deleted any lock whose remaining lease was under 5m —
+	// every freshly-acquired ≤5m TTL lock was eligible on the next
+	// cleaner tick, surfacing to holders as spurious "document
+	// locked" / "not locked" errors right after acquire.
+	cutoff := pg.Time(time.Now().Add(-5 * time.Minute))
 
 	err := pg.WithTX(ctx, s.pool, func(tx pgx.Tx) error {
 		q := postgres.New(tx)


### PR DESCRIPTION
## Summary

`removeExpiredLocks` set the cleaner cutoff to `time.Now().Add(5 * time.Minute)` and the SQL filter is `expires < cutoff`. That deletes any lock whose remaining lease is under 5 minutes — including every freshly-acquired lock with a ≤ 5m TTL. Combined with `RunCleaner(stopCtx, 5*time.Minute)`, holders observed transient "document locked" / "not locked" errors right after acquire and had to re-acquire on every cleaner cycle.

Sign-flip: `cutoff = now - 5m`, so the cleaner now sweeps only locks that have already been expired for at least 5 minutes. Storage-reclamation cadence; correctness for live writers was never coming from this query.

## Why the grace period is safe

All RPC paths read the lock through a `LEFT JOIN document_lock ON l.expires > @now` filter, so an expired-but-not-yet-cleaned row is invisible to writers:

- `GetDocumentForUpdate` → `Documents.Update`
- `GetDocumentInfo` → `Documents.GetMeta`
- `BulkGetDocumentInfo` → `Documents.BulkGetMeta` / `BulkGet`

Write paths handle stale rows directly:

- `Lock` → preflight sees `info.Lock.Token == ""` for an expired row, treats it as free, then `DeleteExpiredDocumentLock` with `cutoff = now` for that one UUID before `InsertDocumentLock`. The row-level `FOR UPDATE OF d` serialises concurrent acquires.
- `ExtendLock` → expired row → `info.Lock.Token == ""` → returns `not locked`. `UpdateDocumentLock` only fires after a token-match check.
- `Unlock` → expired row → treated as no lock (success no-op).

## Observed impact (elephant-collab, stage)

```
04:46:17  ERROR Snapshot  "failed to update document: document locked"  sub=core://user/5558
04:46:28  WARN  auto-snapshot: snapshotOne failed (same error)
04:46:28  INFO  refreshed expired repository lock (lock-pinger)
```

…and every subsequent collab lock-pinger tick had to go through `RefreshExpiredLock` rather than a plain `ExtendLock`, because the cleaner kept deleting the freshly-extended lock.