### PR TITLE
add lock exclusivity levels

### DIFF
--- a/postgres/models.go
+++ b/postgres/models.go
@@ -134,13 +134,14 @@ type DocumentArchiveCounter struct {
 }
 
 type DocumentLock struct {
-	UUID    uuid.UUID
-	Token   string
-	Created pgtype.Timestamptz
-	Expires pgtype.Timestamptz
-	URI     pgtype.Text
-	App     pgtype.Text
-	Comment pgtype.Text
+	UUID        uuid.UUID
+	Token       string
+	Created     pgtype.Timestamptz
+	Expires     pgtype.Timestamptz
+	URI         pgtype.Text
+	App         pgtype.Text
+	Comment     pgtype.Text
+	Exclusivity string
 }
 
 type DocumentSchema struct {

--- a/postgres/query.sql
+++ b/postgres/query.sql
@@ -3,7 +3,7 @@ SELECT d.uri, d.type, d.current_version, d.main_doc, d.language, d.system_state,
        d.nonce AS nonce,
        l.uuid as lock_uuid, l.uri as lock_uri, l.created as lock_created,
        l.expires as lock_expires, l.app as lock_app, l.comment as lock_comment,
-       l.token as lock_token
+       l.token as lock_token, l.exclusivity as lock_exclusivity
 FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > @now
 WHERE d.uuid = $1
@@ -107,8 +107,9 @@ SELECT
         d.system_state, d.main_doc, d.nonce, l.uuid as lock_uuid, l.uri as lock_uri,
         l.created as lock_created, l.expires as lock_expires, l.app as lock_app,
         l.comment as lock_comment, l.token as lock_token,
+        l.exclusivity as lock_exclusivity,
         ws.step as workflow_state, ws.checkpoint as workflow_checkpoint
-FROM document as d 
+FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > @now
 LEFT JOIN workflow_state AS ws ON ws.uuid = d.uuid
 WHERE d.uuid = @uuid;
@@ -119,6 +120,7 @@ SELECT
         d.system_state, d.main_doc, d.nonce, l.uuid as lock_uuid, l.uri as lock_uri,
         l.created as lock_created, l.expires as lock_expires, l.app as lock_app,
         l.comment as lock_comment, l.token as lock_token,
+        l.exclusivity as lock_exclusivity,
         ws.step as workflow_state, ws.checkpoint as workflow_checkpoint
 FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > @now
@@ -729,9 +731,9 @@ DELETE FROM status_rule WHERE type = @type AND name = @name;
 
 -- name: InsertDocumentLock :exec
 INSERT INTO document_lock(
-  uuid, token, created, expires, uri, app, comment
+  uuid, token, created, expires, uri, app, comment, exclusivity
 ) VALUES(
-  @uuid, @token, @created, @expires, @uri, @app, @comment
+  @uuid, @token, @created, @expires, @uri, @app, @comment, @exclusivity
 );
 
 -- name: UpdateDocumentLock :exec

--- a/postgres/query.sql.go
+++ b/postgres/query.sql.go
@@ -297,6 +297,7 @@ SELECT
         d.system_state, d.main_doc, d.nonce, l.uuid as lock_uuid, l.uri as lock_uri,
         l.created as lock_created, l.expires as lock_expires, l.app as lock_app,
         l.comment as lock_comment, l.token as lock_token,
+        l.exclusivity as lock_exclusivity,
         ws.step as workflow_state, ws.checkpoint as workflow_checkpoint
 FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > $1
@@ -328,6 +329,7 @@ type BulkGetDocumentInfoRow struct {
 	LockApp            pgtype.Text
 	LockComment        pgtype.Text
 	LockToken          pgtype.Text
+	LockExclusivity    pgtype.Text
 	WorkflowState      pgtype.Text
 	WorkflowCheckpoint pgtype.Text
 }
@@ -360,6 +362,7 @@ func (q *Queries) BulkGetDocumentInfo(ctx context.Context, arg BulkGetDocumentIn
 			&i.LockApp,
 			&i.LockComment,
 			&i.LockToken,
+			&i.LockExclusivity,
 			&i.WorkflowState,
 			&i.WorkflowCheckpoint,
 		); err != nil {
@@ -1901,7 +1904,7 @@ SELECT d.uri, d.type, d.current_version, d.main_doc, d.language, d.system_state,
        d.nonce AS nonce,
        l.uuid as lock_uuid, l.uri as lock_uri, l.created as lock_created,
        l.expires as lock_expires, l.app as lock_app, l.comment as lock_comment,
-       l.token as lock_token
+       l.token as lock_token, l.exclusivity as lock_exclusivity
 FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > $2
 WHERE d.uuid = $1
@@ -1914,20 +1917,21 @@ type GetDocumentForUpdateParams struct {
 }
 
 type GetDocumentForUpdateRow struct {
-	URI            string
-	Type           string
-	CurrentVersion int64
-	MainDoc        pgtype.UUID
-	Language       pgtype.Text
-	SystemState    pgtype.Text
-	Nonce          uuid.UUID
-	LockUuid       pgtype.UUID
-	LockUri        pgtype.Text
-	LockCreated    pgtype.Timestamptz
-	LockExpires    pgtype.Timestamptz
-	LockApp        pgtype.Text
-	LockComment    pgtype.Text
-	LockToken      pgtype.Text
+	URI             string
+	Type            string
+	CurrentVersion  int64
+	MainDoc         pgtype.UUID
+	Language        pgtype.Text
+	SystemState     pgtype.Text
+	Nonce           uuid.UUID
+	LockUuid        pgtype.UUID
+	LockUri         pgtype.Text
+	LockCreated     pgtype.Timestamptz
+	LockExpires     pgtype.Timestamptz
+	LockApp         pgtype.Text
+	LockComment     pgtype.Text
+	LockToken       pgtype.Text
+	LockExclusivity pgtype.Text
 }
 
 func (q *Queries) GetDocumentForUpdate(ctx context.Context, arg GetDocumentForUpdateParams) (GetDocumentForUpdateRow, error) {
@@ -1948,6 +1952,7 @@ func (q *Queries) GetDocumentForUpdate(ctx context.Context, arg GetDocumentForUp
 		&i.LockApp,
 		&i.LockComment,
 		&i.LockToken,
+		&i.LockExclusivity,
 	)
 	return i, err
 }
@@ -1989,8 +1994,9 @@ SELECT
         d.system_state, d.main_doc, d.nonce, l.uuid as lock_uuid, l.uri as lock_uri,
         l.created as lock_created, l.expires as lock_expires, l.app as lock_app,
         l.comment as lock_comment, l.token as lock_token,
+        l.exclusivity as lock_exclusivity,
         ws.step as workflow_state, ws.checkpoint as workflow_checkpoint
-FROM document as d 
+FROM document as d
 LEFT JOIN document_lock as l ON d.uuid = l.uuid AND l.expires > $1
 LEFT JOIN workflow_state AS ws ON ws.uuid = d.uuid
 WHERE d.uuid = $2
@@ -2020,6 +2026,7 @@ type GetDocumentInfoRow struct {
 	LockApp            pgtype.Text
 	LockComment        pgtype.Text
 	LockToken          pgtype.Text
+	LockExclusivity    pgtype.Text
 	WorkflowState      pgtype.Text
 	WorkflowCheckpoint pgtype.Text
 }
@@ -2046,6 +2053,7 @@ func (q *Queries) GetDocumentInfo(ctx context.Context, arg GetDocumentInfoParams
 		&i.LockApp,
 		&i.LockComment,
 		&i.LockToken,
+		&i.LockExclusivity,
 		&i.WorkflowState,
 		&i.WorkflowCheckpoint,
 	)
@@ -4206,20 +4214,21 @@ func (q *Queries) InsertDocument(ctx context.Context, arg InsertDocumentParams) 
 
 const insertDocumentLock = `-- name: InsertDocumentLock :exec
 INSERT INTO document_lock(
-  uuid, token, created, expires, uri, app, comment
+  uuid, token, created, expires, uri, app, comment, exclusivity
 ) VALUES(
-  $1, $2, $3, $4, $5, $6, $7
+  $1, $2, $3, $4, $5, $6, $7, $8
 )
 `
 
 type InsertDocumentLockParams struct {
-	UUID    uuid.UUID
-	Token   string
-	Created pgtype.Timestamptz
-	Expires pgtype.Timestamptz
-	URI     pgtype.Text
-	App     pgtype.Text
-	Comment pgtype.Text
+	UUID        uuid.UUID
+	Token       string
+	Created     pgtype.Timestamptz
+	Expires     pgtype.Timestamptz
+	URI         pgtype.Text
+	App         pgtype.Text
+	Comment     pgtype.Text
+	Exclusivity string
 }
 
 func (q *Queries) InsertDocumentLock(ctx context.Context, arg InsertDocumentLockParams) error {
@@ -4231,6 +4240,7 @@ func (q *Queries) InsertDocumentLock(ctx context.Context, arg InsertDocumentLock
 		arg.URI,
 		arg.App,
 		arg.Comment,
+		arg.Exclusivity,
 	)
 	return err
 }

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -197,7 +197,8 @@ CREATE TABLE public.document_lock (
     expires timestamp with time zone NOT NULL,
     uri text,
     app text,
-    comment text
+    comment text,
+    exclusivity text DEFAULT 'document'::text NOT NULL
 );
 
 

--- a/repository/docstore.go
+++ b/repository/docstore.go
@@ -573,20 +573,39 @@ type ACLEntry struct {
 }
 
 type Lock struct {
-	Token   string
-	URI     string
-	Created time.Time
-	Expires time.Time
-	App     string
-	Comment string
+	Token       string
+	URI         string
+	Created     time.Time
+	Expires     time.Time
+	App         string
+	Comment     string
+	Exclusivity LockExclusivity
 }
 
+// LockExclusivity controls which operations a document lock blocks for
+// callers that don't hold the lock token. Document updates are always
+// blocked by a lock; the exclusivity level can extend the lock to also
+// cover status and ACL updates.
+type LockExclusivity string
+
+const (
+	// LockExclusivityDocument blocks document updates only.
+	LockExclusivityDocument LockExclusivity = "document"
+	// LockExclusivityStatus blocks document and status updates.
+	LockExclusivityStatus LockExclusivity = "status"
+	// LockExclusivityACL blocks document and ACL updates.
+	LockExclusivityACL LockExclusivity = "acl"
+	// LockExclusivityExclusive blocks document, status, and ACL updates.
+	LockExclusivityExclusive LockExclusivity = "exclusive"
+)
+
 type LockRequest struct {
-	UUID    uuid.UUID
-	URI     string
-	TTL     int32
-	App     string
-	Comment string
+	UUID        uuid.UUID
+	URI         string
+	TTL         int32
+	App         string
+	Comment     string
+	Exclusivity LockExclusivity
 }
 
 type LockResult struct {

--- a/repository/documents_api.go
+++ b/repository/documents_api.go
@@ -354,11 +354,12 @@ func DocumentMetaToRPC(meta *DocumentMeta) *repository.DocumentMeta {
 
 	if meta.Lock.Expires != (time.Time{}) {
 		resp.Lock = &repository.Lock{
-			Uri:     meta.Lock.URI,
-			Created: meta.Lock.Created.Format(time.RFC3339),
-			Expires: meta.Lock.Expires.Format(time.RFC3339),
-			App:     meta.Lock.App,
-			Comment: meta.Lock.Comment,
+			Uri:         meta.Lock.URI,
+			Created:     meta.Lock.Created.Format(time.RFC3339),
+			Expires:     meta.Lock.Expires.Format(time.RFC3339),
+			App:         meta.Lock.App,
+			Comment:     meta.Lock.Comment,
+			Exclusivity: lockExclusivityToRPC(meta.Lock.Exclusivity),
 		}
 	}
 
@@ -1601,12 +1602,18 @@ func (a *DocumentsService) Get(
 	var lockGrant *repository.LockGrant
 
 	if req.Lock != nil {
+		exclusivity, err := lockExclusivityFromRPC(req.Lock.Exclusivity)
+		if err != nil {
+			return nil, twirp.InvalidArgumentError("lock.exclusivity", err.Error())
+		}
+
 		lock, err := a.store.Lock(ctx, LockRequest{
-			UUID:    docUUID,
-			TTL:     req.Lock.Ttl,
-			URI:     auth.Claims.Subject,
-			App:     req.Lock.App,
-			Comment: req.Lock.Comment,
+			UUID:        docUUID,
+			TTL:         req.Lock.Ttl,
+			URI:         auth.Claims.Subject,
+			App:         req.Lock.App,
+			Comment:     req.Lock.Comment,
+			Exclusivity: exclusivity,
 		})
 
 		switch {
@@ -2714,12 +2721,18 @@ func (a *DocumentsService) Lock(
 		return nil, twirp.RequiredArgumentError("ttl")
 	}
 
+	exclusivity, err := lockExclusivityFromRPC(req.Exclusivity)
+	if err != nil {
+		return nil, twirp.InvalidArgumentError("exclusivity", err.Error())
+	}
+
 	lock, err := a.store.Lock(ctx, LockRequest{
-		UUID:    docUUID,
-		TTL:     req.Ttl,
-		URI:     auth.Claims.Subject,
-		App:     req.App,
-		Comment: req.Comment,
+		UUID:        docUUID,
+		TTL:         req.Ttl,
+		URI:         auth.Claims.Subject,
+		App:         req.App,
+		Comment:     req.Comment,
+		Exclusivity: exclusivity,
 	})
 
 	switch {
@@ -2765,7 +2778,42 @@ func lockConflictTwirp(err error) twirp.Error {
 		twerr = twerr.WithMeta("lock_expires", conflict.Holder.Expires.Format(time.RFC3339))
 	}
 
+	if conflict.Holder.Exclusivity != "" {
+		twerr = twerr.WithMeta("lock_exclusivity", string(conflict.Holder.Exclusivity))
+	}
+
 	return twerr
+}
+
+func lockExclusivityFromRPC(
+	e repository.LockExclusivity,
+) (LockExclusivity, error) {
+	switch e {
+	case repository.LockExclusivity_LOCK_DOCUMENT:
+		return LockExclusivityDocument, nil
+	case repository.LockExclusivity_LOCK_STATUS:
+		return LockExclusivityStatus, nil
+	case repository.LockExclusivity_LOCK_ACL:
+		return LockExclusivityACL, nil
+	case repository.LockExclusivity_LOCK_EXCLUSIVE:
+		return LockExclusivityExclusive, nil
+	}
+
+	return "", fmt.Errorf("unknown lock exclusivity value %d", e)
+}
+
+func lockExclusivityToRPC(e LockExclusivity) repository.LockExclusivity {
+	switch e {
+	case LockExclusivityStatus:
+		return repository.LockExclusivity_LOCK_STATUS
+	case LockExclusivityACL:
+		return repository.LockExclusivity_LOCK_ACL
+	case LockExclusivityExclusive:
+		return repository.LockExclusivity_LOCK_EXCLUSIVE
+	case LockExclusivityDocument:
+	}
+
+	return repository.LockExclusivity_LOCK_DOCUMENT
 }
 
 // ExtendLock extends the expiration of an existing lock.

--- a/repository/documents_api_test.go
+++ b/repository/documents_api_test.go
@@ -2224,6 +2224,188 @@ func TestDocumentLocking(t *testing.T) {
 	test.Must(t, err, "unlock non-existing document")
 }
 
+func TestDocumentLockExclusivity(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	logger := slog.New(test.NewLogHandler(t, slog.LevelInfo))
+	ctx := t.Context()
+	tc := testingAPIServer(t, logger, testingServerOptions{})
+
+	client := tc.DocumentsClient(t,
+		itest.StandardClaims(t, "doc_read doc_write doc_delete"))
+
+	const (
+		docUUID = "3ec96c99-ed75-4a2c-bf4d-29892e6d7b7c"
+		docURI  = "article://test/lock-exclusivity"
+	)
+
+	doc := baseDocument(docUUID, docURI)
+
+	res, err := client.Update(ctx, &repository.UpdateRequest{
+		Uuid:     docUUID,
+		Document: doc,
+	})
+	test.Must(t, err, "create test article")
+
+	statusUpdate := []*repository.StatusUpdate{
+		{Name: "done", Version: res.Version},
+	}
+
+	aclUpdate := []*repository.ACLEntry{
+		{Uri: "user://test/other", Permissions: []string{"r"}},
+	}
+
+	// A default lock only blocks document updates.
+	lock, err := client.Lock(ctx, &repository.LockRequest{
+		Uuid: docUUID,
+		Ttl:  10000,
+	})
+	test.Must(t, err, "lock the document with default exclusivity")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:     docUUID,
+		Document: doc,
+	})
+	test.MustNot(t, err, "update a document with a default lock")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:   docUUID,
+		Status: statusUpdate,
+	})
+	test.Must(t, err, "set a status on a document with a default lock")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Acl:  aclUpdate,
+	})
+	test.Must(t, err, "update the ACL of a document with a default lock")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:      docUUID,
+		Status:    statusUpdate,
+		LockToken: "0e2e44ad-1a1c-4bc9-8a4a-44b35e3a0fcc",
+	})
+	test.MustNot(t, err, "set a status using the wrong lock token")
+
+	_, err = client.Unlock(ctx, &repository.UnlockRequest{
+		Uuid:  docUUID,
+		Token: lock.Token,
+	})
+	test.Must(t, err, "unlock the document")
+
+	// A status lock blocks status updates, but not ACL updates.
+	lock, err = client.Lock(ctx, &repository.LockRequest{
+		Uuid:        docUUID,
+		Ttl:         10000,
+		Exclusivity: repository.LockExclusivity_LOCK_STATUS,
+	})
+	test.Must(t, err, "lock the document with status exclusivity")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:   docUUID,
+		Status: statusUpdate,
+	})
+	test.MustNot(t, err, "set a status on a status-locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Acl:  aclUpdate,
+	})
+	test.Must(t, err, "update the ACL of a status-locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:      docUUID,
+		Status:    statusUpdate,
+		LockToken: lock.Token,
+	})
+	test.Must(t, err, "set a status on a status-locked document with the lock token")
+
+	_, err = client.Unlock(ctx, &repository.UnlockRequest{
+		Uuid:  docUUID,
+		Token: lock.Token,
+	})
+	test.Must(t, err, "unlock the document")
+
+	// An ACL lock blocks ACL updates, but not status updates.
+	lock, err = client.Lock(ctx, &repository.LockRequest{
+		Uuid:        docUUID,
+		Ttl:         10000,
+		Exclusivity: repository.LockExclusivity_LOCK_ACL,
+	})
+	test.Must(t, err, "lock the document with ACL exclusivity")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Acl:  aclUpdate,
+	})
+	test.MustNot(t, err, "update the ACL of an ACL-locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:   docUUID,
+		Status: statusUpdate,
+	})
+	test.Must(t, err, "set a status on an ACL-locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:      docUUID,
+		Acl:       aclUpdate,
+		LockToken: lock.Token,
+	})
+	test.Must(t, err, "update the ACL of an ACL-locked document with the lock token")
+
+	_, err = client.Unlock(ctx, &repository.UnlockRequest{
+		Uuid:  docUUID,
+		Token: lock.Token,
+	})
+	test.Must(t, err, "unlock the document")
+
+	// An exclusive lock blocks document, status, and ACL updates.
+	lock, err = client.Lock(ctx, &repository.LockRequest{
+		Uuid:        docUUID,
+		Ttl:         10000,
+		Exclusivity: repository.LockExclusivity_LOCK_EXCLUSIVE,
+	})
+	test.Must(t, err, "lock the document with exclusive exclusivity")
+
+	meta, err := client.GetMeta(ctx, &repository.GetMetaRequest{
+		Uuid: docUUID,
+	})
+	test.Must(t, err, "fetch document meta")
+	test.NotNil(t, meta.Meta.Lock, "document should have a lock")
+	test.Equal(t, meta.Meta.Lock.Exclusivity,
+		repository.LockExclusivity_LOCK_EXCLUSIVE,
+		"expected the lock exclusivity to be exposed in the meta")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:     docUUID,
+		Document: doc,
+	})
+	test.MustNot(t, err, "update an exclusively locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:   docUUID,
+		Status: statusUpdate,
+	})
+	test.MustNot(t, err, "set a status on an exclusively locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid: docUUID,
+		Acl:  aclUpdate,
+	})
+	test.MustNot(t, err, "update the ACL of an exclusively locked document")
+
+	_, err = client.Update(ctx, &repository.UpdateRequest{
+		Uuid:      docUUID,
+		Document:  doc,
+		Status:    statusUpdate,
+		Acl:       aclUpdate,
+		LockToken: lock.Token,
+	})
+	test.Must(t, err, "perform a full update of an exclusively locked document with the lock token")
+}
+
 func TestGetWithLock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/repository/pgstore.go
+++ b/repository/pgstore.go
@@ -381,7 +381,7 @@ func (s *PGDocStore) Delete(
 		return nil
 	}
 
-	lock := checkLock(mainInfo.Lock, req.LockToken)
+	lock := checkLock(mainInfo.Lock, req.LockToken, lockOps{document: true})
 	if lock == lockCheckDenied {
 		return DocStoreErrorf(ErrCodeDocumentLock, "document locked")
 	}
@@ -1480,12 +1480,13 @@ func (s *PGDocStore) GetDocumentMeta(
 		WorkflowState:      info.WorkflowState.String,
 		WorkflowCheckpoint: info.WorkflowCheckpoint.String,
 		Lock: Lock{
-			Token:   info.LockToken.String,
-			URI:     info.LockUri.String,
-			Created: info.LockCreated.Time,
-			Expires: info.LockExpires.Time,
-			App:     info.LockApp.String,
-			Comment: info.LockComment.String,
+			Token:       info.LockToken.String,
+			URI:         info.LockUri.String,
+			Created:     info.LockCreated.Time,
+			Expires:     info.LockExpires.Time,
+			App:         info.LockApp.String,
+			Comment:     info.LockComment.String,
+			Exclusivity: LockExclusivity(info.LockExclusivity.String),
 		},
 	}
 
@@ -1570,12 +1571,13 @@ func (s *PGDocStore) BulkGetDocumentMeta(
 			WorkflowState:      info.WorkflowState.String,
 			WorkflowCheckpoint: info.WorkflowCheckpoint.String,
 			Lock: Lock{
-				Token:   info.LockToken.String,
-				URI:     info.LockUri.String,
-				Created: info.LockCreated.Time,
-				Expires: info.LockExpires.Time,
-				App:     info.LockApp.String,
-				Comment: info.LockComment.String,
+				Token:       info.LockToken.String,
+				URI:         info.LockUri.String,
+				Created:     info.LockCreated.Time,
+				Expires:     info.LockExpires.Time,
+				App:         info.LockApp.String,
+				Comment:     info.LockComment.String,
+				Exclusivity: LockExclusivity(info.LockExclusivity.String),
 			},
 		}
 
@@ -1839,17 +1841,53 @@ func (s *PGDocStore) CheckPermissions(
 	return PermissionCheckAllowed, nil
 }
 
+// lockOps describes the operations that an update performs, and is used to
+// determine whether a document lock blocks the update.
+type lockOps struct {
+	document bool
+	status   bool
+	acl      bool
+}
+
 func checkLock(
 	lock Lock,
 	token string,
+	ops lockOps,
 ) checkLockResult {
-	// We only need to validate the token; the expiration has already been
-	// handled in the SQL layer.
+	// We don't need to check the expiration of the lock; that has already
+	// been handled in the SQL layer.
 	if token == lock.Token {
 		return lockCheckAllowed
 	}
 
-	return lockCheckDenied
+	// A non-matching token is always an error, regardless of what the
+	// update does: the caller believes that it holds a lock that it
+	// doesn't.
+	if token != "" {
+		return lockCheckDenied
+	}
+
+	if ops.document {
+		return lockCheckDenied
+	}
+
+	switch lock.Exclusivity {
+	case LockExclusivityDocument:
+	case LockExclusivityStatus:
+		if ops.status {
+			return lockCheckDenied
+		}
+	case LockExclusivityACL:
+		if ops.acl {
+			return lockCheckDenied
+		}
+	case LockExclusivityExclusive:
+		if ops.status || ops.acl {
+			return lockCheckDenied
+		}
+	}
+
+	return lockCheckAllowed
 }
 
 type checkLockResult int
@@ -2005,7 +2043,13 @@ func (s *PGDocStore) Update(
 			}
 		}
 
-		lock := checkLock(info.Lock, state.Request.LockToken)
+		lock := checkLock(info.Lock, state.Request.LockToken, lockOps{
+			document: state.Doc != nil ||
+				len(state.Request.AttachObjects) > 0 ||
+				len(state.Request.DetachObjects) > 0,
+			status: len(state.Request.Status) > 0,
+			acl:    len(state.Request.ACL) > 0,
+		})
 		if lock == lockCheckDenied {
 			return nil, DocStoreErrorf(ErrCodeDocumentLock, "document locked")
 		}
@@ -3575,6 +3619,10 @@ func (s *PGDocStore) Lock(ctx context.Context, req LockRequest) (LockResult, err
 	now := time.Now()
 	expires := now.Add(time.Millisecond * time.Duration(req.TTL))
 
+	if req.Exclusivity == "" {
+		req.Exclusivity = LockExclusivityDocument
+	}
+
 	res := LockResult{
 		Created: now,
 		Expires: expires,
@@ -3616,13 +3664,14 @@ func (s *PGDocStore) Lock(ctx context.Context, req LockRequest) (LockResult, err
 		}
 
 		err = q.InsertDocumentLock(ctx, postgres.InsertDocumentLockParams{
-			UUID:    req.UUID,
-			Token:   res.Token,
-			Created: pg.Time(now),
-			Expires: pg.Time(expires),
-			URI:     pg.TextOrNull(req.URI),
-			App:     pg.TextOrNull(req.App),
-			Comment: pg.TextOrNull(req.Comment),
+			UUID:        req.UUID,
+			Token:       res.Token,
+			Created:     pg.Time(now),
+			Expires:     pg.Time(expires),
+			URI:         pg.TextOrNull(req.URI),
+			App:         pg.TextOrNull(req.App),
+			Comment:     pg.TextOrNull(req.Comment),
+			Exclusivity: string(req.Exclusivity),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to insert document lock: %w", err)
@@ -3663,8 +3712,7 @@ func (s *PGDocStore) UpdateLock(ctx context.Context, req UpdateLockRequest) (Loc
 			return DocStoreErrorf(ErrCodeNoSuchLock, "not locked")
 		}
 
-		lock := checkLock(info.Lock, req.Token)
-		if lock == lockCheckDenied {
+		if req.Token != info.Lock.Token {
 			return DocStoreErrorf(ErrCodeDocumentLock, "invalid lock token")
 		}
 
@@ -4798,12 +4846,13 @@ func (s *PGDocStore) UpdatePreflight(
 		MainDocType: mainDocType,
 		Language:    info.Language.String,
 		Lock: Lock{
-			URI:     info.LockUri.String,
-			Token:   info.LockToken.String,
-			Created: info.LockCreated.Time,
-			Expires: info.LockExpires.Time,
-			App:     info.LockApp.String,
-			Comment: info.LockComment.String,
+			URI:         info.LockUri.String,
+			Token:       info.LockToken.String,
+			Created:     info.LockCreated.Time,
+			Expires:     info.LockExpires.Time,
+			App:         info.LockApp.String,
+			Comment:     info.LockComment.String,
+			Exclusivity: LockExclusivity(info.LockExclusivity.String),
 		},
 	}, nil
 }

--- a/schema/027_lock_exclusivity.sql
+++ b/schema/027_lock_exclusivity.sql
@@ -1,0 +1,11 @@
+-- Write your migrate up statements here
+
+alter table document_lock
+  add column exclusivity text not null default 'document';
+
+---- create above / drop below ----
+
+alter table document_lock drop column exclusivity;
+
+-- Write your migrate down statements here. If this migration is irreversible
+-- Then delete the separator line above.


### PR DESCRIPTION
By default a document lock now only blocks document updates, matching the documented API behaviour. Clients can set the lock exclusivity to also block status updates, ACL updates, or both (exclusive).

API changes in https://github.com/ttab/elephant-api/pull/65