### PR TITLE
rewrite metric help texts to explain operational meaning

### DIFF
--- a/repository/archive.go
+++ b/repository/archive.go
@@ -108,52 +108,63 @@ func NewArchiver(opts ArchiverOptions) (*Archiver, error) {
 
 	m.Gauge(&a.eventArchiverPos, prometheus.GaugeOpts{
 		Name: "elephant_archiver_event_archiver_position",
-		Help: "Eventlog archiver position.",
+		Help: "Eventlog position the archiver has processed; a position " +
+			"that stops advancing while events are written means " +
+			"archiving has stalled.",
 	})
 
 	m.CounterVec(&a.eventsArchived, prometheus.CounterOpts{
 		Name: "elephant_event_archived_total",
-		Help: "Number of document events archived.",
+		Help: "Eventlog items archived to S3 by event type; 'error' " +
+			"statuses mean archiving is failing and being retried.",
 	}, []string{"event_type", metricLabelStatus})
 
 	m.CounterVec(&a.deletesProcessed, prometheus.CounterOpts{
 		Name: "elephant_archiver_deletes_total",
-		Help: "Number of document deletes processed.",
+		Help: "Document delete finalizations processed; 'error' statuses " +
+			"mean deletes are failing and being retried.",
 	}, []string{metricLabelStatus})
 
 	m.CounterVec(&a.deleteMoves, prometheus.CounterOpts{
 		Name: "elephant_archiver_delete_moves_total",
-		Help: "Number of objects moves as part of delete processing.",
+		Help: "S3 object moves performed as part of delete processing; " +
+			"'error' statuses mean delete finalization is failing.",
 	}, []string{metricLabelStatus})
 
 	m.CounterVec(&a.restoresProcessed, prometheus.CounterOpts{
 		Name: "elephant_archiver_restores_total",
-		Help: "Number of document restores processed.",
+		Help: "Document restores processed; 'error' statuses mean " +
+			"restores are failing and being retried.",
 	}, []string{metricLabelStatus})
 
 	m.CounterVec(&a.purgesProcessed, prometheus.CounterOpts{
 		Name: "elephant_archiver_purges_total",
-		Help: "Number of document purges processed.",
+		Help: "Document purges processed; 'error' statuses mean purges " +
+			"are failing and being retried.",
 	}, []string{metricLabelStatus})
 
 	m.CounterVec(&a.purgeDeletes, prometheus.CounterOpts{
 		Name: "elephant_archiver_purge_deletes_total",
-		Help: "Number of objects deleted as part of purge processing.",
+		Help: "S3 objects deleted as part of purge processing; 'error' " +
+			"statuses mean purged document data may remain in the archive.",
 	}, []string{metricLabelStatus})
 
 	m.CounterVec(&a.batchesCreated, prometheus.CounterOpts{
 		Name: "elephant_archiver_batches_created_total",
-		Help: "Number of event batches created.",
+		Help: "Eventlog archive batches created by batch size; a stall " +
+			"while events are archived means batch compaction has stopped.",
 	}, []string{"size", metricLabelStatus})
 
 	m.Gauge(&a.batchArchiverPos1k, prometheus.GaugeOpts{
 		Name: "elephant_archiver_batch_1k_position",
-		Help: "Eventlog batch archiver position for 1k batches.",
+		Help: "Eventlog position of the 1k batch archiver; a position " +
+			"that lags the event archiver means batching has stalled.",
 	})
 
 	m.Gauge(&a.batchArchiverPos10k, prometheus.GaugeOpts{
 		Name: "elephant_archiver_batch_10k_position",
-		Help: "Eventlog batch archiver position for 10k batches.",
+		Help: "Eventlog position of the 10k batch archiver; a position " +
+			"that lags the event archiver means batching has stalled.",
 	})
 
 	if err := m.Err(); err != nil {

--- a/repository/document_stream.go
+++ b/repository/document_stream.go
@@ -128,17 +128,21 @@ func NewDocumentStream(
 
 	prom.CounterVec(&s.mEmitEvents, prometheus.CounterOpts{
 		Name: "repository_docstream_emit_total",
-		Help: "Counts when we 'start' to emit events, and 'ok' on success, 'error' on failure.",
+		Help: "Docstream emit attempts ('start') and their outcomes " +
+			"('ok'/'error'); errors mean subscribers are not receiving " +
+			"document updates.",
 	}, []string{metricLabelStatus})
 
 	prom.Gauge(&s.mPosition, prometheus.GaugeOpts{
 		Name: "repository_docstream_position",
-		Help: "The current eventlog position of the docstream.",
+		Help: "Eventlog position the docstream has fanned out to " +
+			"subscribers; a position that stops advancing while documents " +
+			"are updated means streaming has stalled.",
 	})
 
 	prom.Gauge(&s.mSubscribers, prometheus.GaugeOpts{
 		Name: "repository_docstream_subscribers",
-		Help: "Current docstream subscribers.",
+		Help: "Number of currently connected docstream subscribers.",
 	})
 
 	err := prom.Err()

--- a/repository/eventlog.go
+++ b/repository/eventlog.go
@@ -91,12 +91,14 @@ func NewEventlogBuilder(
 
 	prom.Counter(&eb.starts, prometheus.CounterOpts{
 		Name: "elephant_eventlog_start_total",
-		Help: "Number of times the eventlog has started.",
+		Help: "Starts of the eventlog builder; more than one per process " +
+			"means the builder has crashed and restarted.",
 	})
 
 	prom.CounterVec(&eb.events, prometheus.CounterOpts{
 		Name: "elephant_eventlog_events_total",
-		Help: "Number of received eventlog events.",
+		Help: "Events built from the outbox into the eventlog; a stall " +
+			"while documents are updated means event delivery has stopped.",
 	}, []string{"type", metricLabelDocType})
 
 	if err := prom.Err(); err != nil {

--- a/repository/scheduler.go
+++ b/repository/scheduler.go
@@ -54,7 +54,8 @@ func NewScheduler(
 ) (*Scheduler, error) {
 	scheduledPub := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "elephant_scheduled_publish_total",
-		Help: "The number of attempts that have been made to publish documents",
+		Help: "Scheduled publish attempts by outcome; failures mean " +
+			"documents due for publication are not going out.",
 	}, []string{"outcome"})
 
 	err := metricsRegisterer.Register(scheduledPub)
@@ -65,7 +66,9 @@ func NewScheduler(
 
 	delayed := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "elephant_scheduled_delayed",
-		Help: "The number of documents whose scheduled publish has been delayed.",
+		Help: "Documents whose scheduled publish time has passed without " +
+			"them being published; non-zero values mean the scheduler is " +
+			"falling behind.",
 	})
 
 	err = metricsRegisterer.Register(delayed)

--- a/repository/socket.go
+++ b/repository/socket.go
@@ -152,18 +152,27 @@ func NewSocketHandler(
 
 	prom.CounterVec(&h.socketRejected, prometheus.CounterOpts{
 		Name: "repository_websocket_rate_limited_total",
+		Help: "Websocket connections and subscriptions rejected; growth " +
+			"means clients are failing to connect or stream, the reason " +
+			"label tells why they were turned away.",
 	}, []string{"reason"})
 
 	prom.Gauge(&h.openSockets, prometheus.GaugeOpts{
 		Name: "repository_open_sockets",
+		Help: "Number of currently open websocket connections.",
 	})
 
 	prom.CounterVec(&h.socketCall, prometheus.CounterOpts{
 		Name: "repository_websocket_call_total",
+		Help: "Websocket API calls received by method; shows client " +
+			"activity and which methods drive load.",
 	}, []string{"method"})
 
 	prom.CounterVec(&h.socketResponse, prometheus.CounterOpts{
 		Name: "repository_websocket_response_total",
+		Help: "Websocket responses by method and response type; the " +
+			"status label carries the error code and is empty on " +
+			"success, so non-empty statuses mean client calls are failing.",
 	}, []string{"method", metricLabelStatus, "response"})
 
 	if err := prom.Err(); err != nil {

--- a/repository/validator.go
+++ b/repository/validator.go
@@ -62,7 +62,9 @@ func NewValidator(
 	v.deprecationsCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elephant_deprecations_total",
-			Help: "Number of encountered deprecations",
+			Help: "Deprecated constructs encountered during document " +
+				"validation by deprecation label; growth means clients " +
+				"are still writing deprecated content.",
 		}, []string{"label"})
 	if err := metricsRegisterer.Register(v.deprecationsCounter); err != nil {
 		return nil, fmt.Errorf("register deprecations metric: %w", err)
@@ -71,7 +73,9 @@ func NewValidator(
 	v.docsWithDeprecationsCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elephant_docs_with_deprecations_total",
-			Help: "Number of encountered documents with deprecations",
+			Help: "Documents containing deprecated constructs by document " +
+				"type; growth means clients are still writing deprecated " +
+				"content.",
 		}, []string{metricLabelDocType})
 	if err := metricsRegisterer.Register(v.docsWithDeprecationsCounter); err != nil {
 		return nil, fmt.Errorf("register docs with deprecations metric: %w", err)
@@ -80,7 +84,9 @@ func NewValidator(
 	v.pendingFailureCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elephant_pending_validation_failures_total",
-			Help: "Number of validation failures against the pending schema generation",
+			Help: "Validation failures against the pending, not yet " +
+				"active, schema generation; these predict documents that " +
+				"would become invalid if the pending schemas were activated.",
 		}, []string{metricLabelDocType, "error"})
 	if err := metricsRegisterer.Register(v.pendingFailureCounter); err != nil {
 		return nil, fmt.Errorf("register pending validation metric: %w", err)

--- a/sinks/eventsink.go
+++ b/sinks/eventsink.go
@@ -72,7 +72,8 @@ func NewEventForwarder(opts EventForwarderOptions) (*EventForwarder, error) {
 	restarts := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elephant_event_forwarder_restarts_total",
-			Help: "Number of times the event forwarder has restarted.",
+			Help: "Restarts of the event forwarder; a growing count " +
+				"means forwarding to the sink is failing and being retried.",
 		}, []string{metricLabelName})
 	if err := opts.MetricsRegisterer.Register(restarts); err != nil {
 		return nil, fmt.Errorf("failed to register metric: %w", err)
@@ -81,15 +82,18 @@ func NewEventForwarder(opts EventForwarderOptions) (*EventForwarder, error) {
 	skips := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elephant_event_forwarder_skipped_total",
-			Help: "Number of times events have been skipped by the forwarder.",
+			Help: "Events the forwarder skipped rather than delivered; " +
+				"sustained growth means sink consumers are missing events, " +
+				"the reason label tells why.",
 		}, []string{metricLabelName, "type", "reason"})
 	if err := opts.MetricsRegisterer.Register(skips); err != nil {
 		return nil, fmt.Errorf("failed to register metric: %w", err)
 	}
 
 	latency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "elephant_event_forwarder_latency_seconds",
-		Help:    "Observed time between event time and sink submission.",
+		Name: "elephant_event_forwarder_latency_seconds",
+		Help: "Time from event creation to sink delivery; rising values " +
+			"mean the forwarder is falling behind the eventlog.",
 		Buckets: prometheus.ExponentialBuckets(0.100, 2, 11),
 	}, []string{metricLabelName})
 	if err := opts.MetricsRegisterer.Register(latency); err != nil {


### PR DESCRIPTION
## Summary

Audit of all 24 metric declarations against the metrics guidelines: help text should be a sentence that tells an operator what a change in the metric means, not just what is counted. Names and labels are untouched, so no dashboards or alerts are affected.

- Rewrote every `Help` string in `repository/` and `sinks/` to state the operational consequence (e.g. `elephant_pending_validation_failures_total` now says failures predict documents that would become invalid if the pending schemas were activated).
- Added missing `Help` to the four websocket metrics (`repository_websocket_rate_limited_total`, `repository_open_sockets`, `repository_websocket_call_total`, `repository_websocket_response_total`), which had none at all.
- Fixed the "Number of objects moves" typo and added missing trailing periods.